### PR TITLE
Update toggle checked state if prop changes

### DIFF
--- a/src/components/Toggle/toggle.js
+++ b/src/components/Toggle/toggle.js
@@ -111,6 +111,12 @@ class Toggle extends Component {
     checked: !!this.props.checked
   };
 
+  componentWillReceiveProps(nextProps) {
+    if (this.state.checked !== nextProps.checked) {
+      this.setState({ checked: nextProps.checked });
+    }
+  };
+
   clickHandler = (e) => {
     const { onChange, disabled } = this.props;
     !disabled &&

--- a/src/components/Toggle/toggle.test.js
+++ b/src/components/Toggle/toggle.test.js
@@ -24,4 +24,10 @@ describe('render', () => {
     input.simulate('change');
     expect(spy).toHaveBeenCalled();
   });
+
+  it('sets \'checked\' state correcly when prop is changed', () => {
+    const wrapper = mount(<Toggle htmlFor="foo" />);
+    wrapper.setProps({ checked: true });
+    expect(wrapper.state().checked).toBe(true);
+  });
 });


### PR DESCRIPTION
### Description
When the `Toggle` state is managed outside the component and we change it, the component keeps the same state.

### How to reproduce it
```js
class App extends Component {
  state = {
    checked: false,
  }

  handleClick = () => {
    this.setState(state => ({ checked: !state.checked }));
  }

  render() {
    return (
      <div>
        <Button onClick={this.handleClick}>Test</Button>
        <Toggle htmlFor="foo" checked={this.state.checked} />
      </div>
    );
  }
}
```