### PR TITLE
Add <CategoryWidget />

### DIFF
--- a/docs/components/categoryWidget.md
+++ b/docs/components/categoryWidget.md
@@ -1,0 +1,50 @@
+The category widget shows the categories returned by [CARTO.js](https://carto.com/documentation/cartojs/) with the amount and the percentage based on the maximum value
+
+```react
+state: { selected: [] }
+---
+<Widget>
+  <Widget.Title>Populated Places</Widget.Title>
+  <Widget.Description>All selected</Widget.Description>
+  <CategoryWidget
+    data={data}
+    onCategoryClick={(selectedCategories) => console.log(selectedCategories)}
+  />
+</Widget>
+```
+
+In this example we use the `onCategoryClick` prop to update our own state and use it to show the number of selected categories, we also show a button to clear the selected categories
+
+```react
+state: { selected: [] }
+---
+<Widget>
+  <Widget.Title>Populated Places</Widget.Title>
+  <Widget.Description>
+    {`${state.selected.length || 'All'} selected`}
+  </Widget.Description>
+  <CategoryWidget
+    data={data}
+    onCategoryClick={(selected) => setState({ selected })}
+    selected={state.selected}
+  />
+  {state.selected.length > 0
+    ? <Button small borderless onClick={() => setState({ selected: [] })}>Clear all</Button>
+    : null
+  }
+</Widget>
+```
+
+### Props
+
+#### **data** (object)
+
+Data returned by [CARTO.js](https://carto.com/documentation/cartojs/docs/#cartodataviewcategorydata).
+
+#### **onCategoryClick** (function)
+
+Returns an array with the selected categories.
+
+#### **selected** (array)
+
+Allows pass the selected categories to the widget, useful when we want to set an initial state, or clear the selected categories.

--- a/docs/index.js
+++ b/docs/index.js
@@ -280,6 +280,17 @@ const pages = [
         path: '/components/gaugechart',
         title: 'Gauge Chart',
         component: require('./components/gaugechart.md')
+      },
+      {
+        imports: {
+          Button: require('../src/components/Button/button.js'),
+          Widget: require('../src/components/Widget/widget.js'),
+          CategoryWidget: require('../src/components/CategoryWidget/categoryWidget.js'),
+          data: require('../src/components/CategoryWidget/categoryWidget.fixtures.js')
+        },
+        path: '/components/categoryWidget',
+        title: 'Category Widget',
+        component: require('./components/categoryWidget.md')
       }
     ]
   }

--- a/src/components/CategoryWidget/__snapshots__/categoryWidget.test.js.snap
+++ b/src/components/CategoryWidget/__snapshots__/categoryWidget.test.js.snap
@@ -1,0 +1,472 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CategoryWidget /> renders with data 1`] = `
+.c0 {
+  padding: 0;
+  list-style: none;
+}
+
+.c3 {
+  margin: 0;
+  font-family: Roboto,sans-serif;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  -webkit-flex: 30%;
+  -ms-flex: 30%;
+  flex: 30%;
+  text-align: right;
+  font-size: 12px;
+  line-height: 20px;
+}
+
+.c2 {
+  margin: 0;
+  font-family: Roboto,sans-serif;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  -webkit-flex: 70%;
+  -ms-flex: 70%;
+  flex: 70%;
+  font-size: 12px;
+  line-height: 20px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.c5 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c5::after {
+  content: '';
+  width: 100%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c6 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c6::after {
+  content: '';
+  width: 65.87586116814657%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c7 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c7::after {
+  content: '';
+  width: 56.91398756809546%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c8 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c8::after {
+  content: '';
+  width: 35.70721516759078%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c9 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c9::after {
+  content: '';
+  width: 24.987519762401334%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c10 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c10::after {
+  content: '';
+  width: 22.461835133865822%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c11 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c11::after {
+  content: '';
+  width: 18.769159056270965%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c12 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c12::after {
+  content: '';
+  width: 13.490218048107968%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c13 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c13::after {
+  content: '';
+  width: 11.521249598950224%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c15 {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: #F5F5F5;
+  position: relative;
+}
+
+.c15::after {
+  content: '';
+  width: 308.41852484133324%;
+  height: 4px;
+  border-radius: 2px;
+  -webkit-transition: background 0.2s ease;
+  transition: background 0.2s ease;
+  position: absolute;
+  max-width: 100%;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  cursor: pointer;
+  margin-bottom: 8px;
+}
+
+.c1 > .c4::after {
+  background: #47DB99;
+}
+
+.c1:hover > .c4::after {
+  background: #22ae70;
+}
+
+.c14 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+  flex-wrap: wrap;
+  cursor: pointer;
+  margin-bottom: 8px;
+}
+
+.c14 > .c4::after {
+  background: #2C2C2C;
+}
+
+.c14:hover > .c4::after {
+  background: #929292;
+}
+
+<ul
+  className="c0"
+>
+  <li
+    className="c1"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      China
+    </p>
+    <span
+      className="c3"
+    >
+      359.0M
+    </span>
+    <div
+      className="c4 c5"
+    />
+  </li>
+  <li
+    className="c1"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      United States of America
+    </p>
+    <span
+      className="c3"
+    >
+      236.5M
+    </span>
+    <div
+      className="c4 c6"
+    />
+  </li>
+  <li
+    className="c1"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      India
+    </p>
+    <span
+      className="c3"
+    >
+      204.3M
+    </span>
+    <div
+      className="c4 c7"
+    />
+  </li>
+  <li
+    className="c1"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      Brazil
+    </p>
+    <span
+      className="c3"
+    >
+      128.2M
+    </span>
+    <div
+      className="c4 c8"
+    />
+  </li>
+  <li
+    className="c1"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      Japan
+    </p>
+    <span
+      className="c3"
+    >
+      89.7M
+    </span>
+    <div
+      className="c4 c9"
+    />
+  </li>
+  <li
+    className="c1"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      Russia
+    </p>
+    <span
+      className="c3"
+    >
+      80.6M
+    </span>
+    <div
+      className="c4 c10"
+    />
+  </li>
+  <li
+    className="c1"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      Mexico
+    </p>
+    <span
+      className="c3"
+    >
+      67.4M
+    </span>
+    <div
+      className="c4 c11"
+    />
+  </li>
+  <li
+    className="c1"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      Indonesia
+    </p>
+    <span
+      className="c3"
+    >
+      48.4M
+    </span>
+    <div
+      className="c4 c12"
+    />
+  </li>
+  <li
+    className="c1"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      Pakistan
+    </p>
+    <span
+      className="c3"
+    >
+      41.4M
+    </span>
+    <div
+      className="c4 c13"
+    />
+  </li>
+  <li
+    className="c14"
+    onClick={[Function]}
+    selected={true}
+  >
+    <p
+      className="c2"
+    >
+      Other
+    </p>
+    <span
+      className="c3"
+    >
+      1.1G
+    </span>
+    <div
+      className="c4 c15"
+    />
+  </li>
+</ul>
+`;
+
+exports[`<CategoryWidget /> renders without crashing 1`] = `
+.c0 {
+  padding: 0;
+  list-style: none;
+}
+
+<ul
+  className="c0"
+/>
+`;

--- a/src/components/CategoryWidget/categoryWidget.fixtures.js
+++ b/src/components/CategoryWidget/categoryWidget.fixtures.js
@@ -1,0 +1,55 @@
+export default {
+  max: 359029623,
+  categories: [
+    {
+      group: false,
+      name: 'China',
+      value: 359029623
+    },
+    {
+      group: false,
+      name: 'United States of America',
+      value: 236513856
+    },
+    {
+      group: false,
+      name: 'India',
+      value: 204338075
+    },
+    {
+      group: false,
+      name: 'Brazil',
+      value: 128199480
+    },
+    {
+      group: false,
+      name: 'Japan',
+      value: 89712598
+    },
+    {
+      group: false,
+      name: 'Russia',
+      value: 80644642
+    },
+    {
+      group: false,
+      name: 'Mexico',
+      value: 67386841
+    },
+    {
+      group: false,
+      name: 'Indonesia',
+      value: 48433879
+    },
+    {
+      group: false,
+      name: 'Pakistan',
+      value: 41364699
+    },
+    {
+      group: true,
+      name: 'Other',
+      value: 1107313867
+    }
+  ]
+}

--- a/src/components/CategoryWidget/categoryWidget.js
+++ b/src/components/CategoryWidget/categoryWidget.js
@@ -1,0 +1,156 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { darken, lighten } from 'polished';
+import { colors } from '../../constants';
+import { readableNumber } from '../../utils';
+import Base from '../Typography/base';
+
+const CATEGORY_OTHER = 'Other';
+
+const Categories = styled.ul`
+  padding: 0;
+  list-style: none;
+`;
+
+const Amount = Base.withComponent('span').extend`
+  flex: 30%;
+  text-align: right;
+  font-size: 12px;
+  line-height: 20px;
+`;
+
+const Name = Base.withComponent('p').extend`
+  flex: 70%;
+  font-size: 12px;
+  line-height: 20px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const Progress = styled.div`
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: ${colors.ui02};
+  position: relative;
+
+  &::after {
+    content: '';
+    width: ${(props) => props.amount}%;
+    height: 4px;
+    border-radius: 2px;
+    transition: background 0.2s ease;
+    position: absolute;
+    max-width: 100%;
+  }
+`;
+
+const Category = styled.li`
+  display: flex;
+  flex-wrap: wrap;
+  cursor: pointer;
+  margin-bottom: 8px;
+
+  & > ${Progress}::after {
+    background: ${(props) => props.isOther ? colors.type01 : colors.brand03};
+  }
+
+  &:hover {
+    & > ${Progress}::after {
+      background: ${(props) => props.isOther ? lighten(0.4, colors.type01) : darken(0.16, colors.brand03)};
+    }
+  }
+
+  ${props => !props.selected && css`
+    ${Amount},
+    ${Name} {
+      color: ${colors.type02};
+    }
+
+    ${Progress}::after {
+      background: ${colors.ui03};
+    }
+
+    &:hover {
+      & > ${Progress}::after {
+        background: ${colors.ui04}
+      }
+    }
+  `}
+`;
+
+Category.displayName = 'Category';
+
+class CategoryWidget extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      selected: props.selected || [],
+    };
+  }
+
+  onCategoryClick = clickedCategory => {
+    const { selected } = this.state;
+
+    const nextSelected = selected.includes(clickedCategory)
+      ? selected.filter(category => category !== clickedCategory)
+      : [...selected, clickedCategory];
+
+    this.setState({ selected: nextSelected });
+
+    this.props.onCategoryClick(nextSelected);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState(prevState => ({ selected: nextProps.selected || prevState.selected }));
+  }
+
+  render() {
+    const { categories, max } = this.props.data;
+    const { selected } = this.state;
+
+    return (
+      <Categories>
+        {categories && categories.map(category => {
+          const { name, value } = category;
+          const isSelected = selected.length === 0 || selected.includes(category)
+
+          return (
+            <Category
+              key={name}
+              onClick={() => this.onCategoryClick(category)}
+              selected={isSelected}
+              isOther={name === CATEGORY_OTHER}
+            >
+              <Name>{name}</Name>
+              <Amount>{readableNumber(value)}</Amount>
+              <Progress amount={(value / max) * 100} />
+            </Category>
+          )
+        })}
+      </Categories>
+    )
+  }
+}
+
+CategoryWidget.propTypes = {
+  data: PropTypes.shape({
+    count: PropTypes.number,
+    max: PropTypes.number,
+    min: PropTypes.number,
+    nulls: PropTypes.number,
+    operation: PropTypes.string,
+    categories: PropTypes.arrayOf(PropTypes.object),
+  }),
+  onCategoryClick: PropTypes.func,
+};
+
+CategoryWidget.defaultProps = {
+  data: {},
+  onCategoryClick: () => {},
+};
+
+export default CategoryWidget;

--- a/src/components/CategoryWidget/categoryWidget.test.js
+++ b/src/components/CategoryWidget/categoryWidget.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { mount } from 'enzyme';
+import CategoryWidget from './categoryWidget';
+import mockData from './categoryWidget.fixtures';
+
+describe('<CategoryWidget />', () => {
+  it('renders without crashing', () => {
+    const component = renderer.create(<CategoryWidget />);
+    const tree = component.toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders with data', () => {
+    const component = renderer.create(<CategoryWidget data={mockData} />);
+    let tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  describe('when a category is clicked', () => {
+    it('adds the category to the state', () => {
+      const component = mount(<CategoryWidget data={mockData} />);
+      const instance = component.instance();
+
+      expect(instance.state.selected.length).toEqual(0);
+
+      component.find('Category').at(1).simulate('click');
+      component.update();
+
+      expect(instance.state.selected.length).toEqual(1);
+      expect(instance.state.selected[0]).toEqual(mockData.categories[1]);
+    });
+
+    it('calls onCategoryClick with the selected categories', () => {
+      const clickMock = jest.fn();
+      const component = mount(<CategoryWidget data={mockData} onCategoryClick={clickMock} />);
+
+
+      component.find('Category').at(0).simulate('click');
+      component.find('Category').at(1).simulate('click');
+
+      expect(clickMock).toHaveBeenCalledWith([
+        mockData.categories[0],
+        mockData.categories[1]
+      ]);
+    });
+  });
+
+  describe('when selected prop is changed', () => {
+    it('updates the state with the new data', () => {
+      const component = mount(
+        <CategoryWidget
+          data={mockData}
+          selected={mockData.categories}
+        />
+      );
+      const instance = component.instance();
+
+      expect(instance.state.selected.length).toEqual(mockData.categories.length);
+
+      component.setProps({ selected: [] });
+      component.update();
+
+      expect(instance.state.selected.length).toEqual(0);
+    });
+  });
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -56,3 +56,4 @@ export { default as Checkbox } from './Checkbox/checkbox';
 export { default as Typeahead } from './Typeahead/typeahead';
 export { default as Widget } from './Widget/widget';
 export { default as GaugeChart } from './GaugeChart/gauge';
+export { default as CategoryWidget } from './CategoryWidget/categoryWidget';

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,3 +6,4 @@ export { default as isNumber } from './is-number';
 export { default as isObject } from './is-object';
 export { default as length } from './length';
 export { default as offset } from './offset';
+export { default as readableNumber } from './readable-number';

--- a/src/utils/readable-number.js
+++ b/src/utils/readable-number.js
@@ -1,0 +1,13 @@
+/**
+ *  Convert long numbers to
+ *  readizable numbers.
+ *
+ *  Ex: 1200 -> 1.2K
+ */
+export default function (number) {
+  if (number >= 1000000000) return (number / 1000000000).toFixed(1) + 'G';
+  if (number >= 1000000) return (number / 1000000).toFixed(1) + 'M';
+  if (number >= 1000) return (number / 1000).toFixed(1) + 'K';
+
+  return number;
+}


### PR DESCRIPTION
### Description
This PR adds a `<CategoryWidget />` component which uses `carto.dataview.Category` from CARTO.js to render the categories.

### Example
```
<Widget>
  <Widget.Title>Populated Places</Widget.Title>
  <Widget.Description>All selected</Widget.Description>
  <CategoryWidget
    data={data}
    onCategoryClick={(selectedCategories) => console.log(selectedCategories)}
  />
</Widget>
```

### Screenshots
![category-widget](https://user-images.githubusercontent.com/905225/38203008-09fa75a4-369e-11e8-9c94-5b85bbb93995.gif)
