### PR TITLE
Add box-sizing to checkbox

### DIFF
--- a/src/components/Checkbox/__snapshots__/checkbox.test.js.snap
+++ b/src/components/Checkbox/__snapshots__/checkbox.test.js.snap
@@ -25,6 +25,7 @@ exports[`render renders with label 1`] = `
   border-radius: 3px;
   position: relative;
   display: block;
+  box-sizing: border-box;
 }
 
 .c0 .Checkbox-check {
@@ -169,6 +170,7 @@ exports[`render renders without crashing 1`] = `
   border-radius: 3px;
   position: relative;
   display: block;
+  box-sizing: border-box;
 }
 
 .c0 .Checkbox-check {

--- a/src/components/Checkbox/checkbox.js
+++ b/src/components/Checkbox/checkbox.js
@@ -27,6 +27,7 @@ const StyleCheck = styled.div`
     border-radius: 3px;
     position: relative;
     display: block;
+    box-sizing: border-box;
   }
 
   .Checkbox-check {

--- a/src/components/Checkbox/checkbox.stories.js
+++ b/src/components/Checkbox/checkbox.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import Checkbox from './checkbox';
+
+storiesOf('Checkbox', module)
+  .add('Default', () => (
+    <div>
+      <h3 className="header">Default</h3>
+      <Checkbox />
+
+      <h3 className="header">Checked</h3>
+      <Checkbox name="three" checked>Hola</Checkbox>
+
+      <h3 className="header">Disabled</h3>
+      <Checkbox disabled>Disabled</Checkbox>
+    </div>
+  ))
+  .add('Disabled', () => (
+    <div>
+      <h3 className="header">Disabled</h3>
+      <Checkbox />
+
+      <h3 className="header">Checked</h3>
+      <Checkbox name="three" disabled checked>Hola</Checkbox>
+    </div>
+  ))
+  .add('With event', () => (
+    <div>
+      <h3 className="header">Default</h3>
+      <Checkbox checked onChange={state => console.log(state)}>Option</Checkbox>
+    </div>
+  ))


### PR DESCRIPTION
## Description
In https://github.com/CartoDB/airship/pull/9 we removed the `reset.css` which broke the checkbox component since it was using the `box-sizing` property from it.

This PR adds the `box-sizing` to the checkbox to fix it.