### PR TITLE
Migrate checkbox to styled-components

### DIFF
--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -6,12 +6,20 @@ A checkbox allows a user to select a value from a small set of options, often bi
 
 ### Props
 
+#### **htmlFor** (string, required)
+
+This property sets the node ID for label and input:
+
+```react
+<Checkbox htmlFor="htmlfor">Hello there</Checkbox>
+```
+
 #### **name** (string)
 
 This property sets the node name for the input:
 
 ```react
-<Checkbox name="two" />
+<Checkbox htmlFor="name" name="checkbox-name" />
 ```
 
 #### **checked** (boolean)
@@ -19,7 +27,9 @@ This property sets the node name for the input:
 Using this prop you can set the initial state as checked:
 
 ```react
-<Checkbox name="three" checked>Hola</Checkbox>
+<Checkbox htmlFor="checked" checked>
+  Checked
+</Checkbox>
 ```
 
 #### **disabled** (boolean)
@@ -27,7 +37,9 @@ Using this prop you can set the initial state as checked:
 Using this prop you can disable the checkbox:
 
 ```react
-<Checkbox disabled>Disabled</Checkbox>
+<Checkbox htmlFor="disabled" disabled>
+  Disabled
+</Checkbox>
 ```
 
 #### **onChange** (function)
@@ -35,7 +47,9 @@ Using this prop you can disable the checkbox:
 Callback to be called when the toggle changes its state:
 
 ```react
-<Checkbox checked onChange={state => console.log(state)}>Option</Checkbox>
+<Checkbox htmlFor="onchange" onChange={state => console.log(state)}>
+  With event
+</Checkbox>
 ```
 
 #### **as** (strong)
@@ -43,5 +57,7 @@ Callback to be called when the toggle changes its state:
 Choose how is rendered the checkbox. You can choose from `div`, `li` or `span`:
 
 ```react
-<Checkbox as='span'>As span</Checkbox>
+<Checkbox htmlFor="as" as='span'>
+  As span
+</Checkbox>
 ```

--- a/src/components/Checkbox/__snapshots__/checkbox.test.js.snap
+++ b/src/components/Checkbox/__snapshots__/checkbox.test.js.snap
@@ -12,11 +12,16 @@ exports[`render renders with label 1`] = `
   align-items: center;
 }
 
-.c0 .Checkbox {
+.c1 {
   position: relative;
 }
 
-.c0 .Checkbox-decoration {
+.c8 {
+  margin-left: 4px;
+  font: 400 12px/20px 'Roboto';
+}
+
+.c4 {
   pointer-events: none;
   width: 16px;
   height: 16px;
@@ -28,17 +33,7 @@ exports[`render renders with label 1`] = `
   box-sizing: border-box;
 }
 
-.c0 .Checkbox-check {
-  stroke-width: 2;
-  stroke: #1785FB;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
-  transform-origin: 50% 50%;
-  stroke-dasharray: 48;
-  stroke-dashoffset: 48;
-}
-
-.c0 .Checkbox-tip {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -49,7 +44,17 @@ exports[`render renders with label 1`] = `
   transform: translateX(1px) translateY(3px);
 }
 
-.c0 .Checkbox-input {
+.c7 {
+  stroke-width: 2;
+  stroke: #1785FB;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+  stroke-dasharray: 48;
+  stroke-dashoffset: 48;
+}
+
+.c2 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -66,63 +71,61 @@ exports[`render renders with label 1`] = `
   border: 1px solid rgba(44,44,44,0.16);
 }
 
-.c0 .Checkbox-input:focus {
+.c2:focus {
   outline: none;
 }
 
-.c0 .Checkbox-input:focus {
+.c2:focus {
   border: 2px solid #1785FB;
 }
 
-.c0 .Checkbox-input:hover {
+.c2:hover {
   border: 1px solid #47DB99;
 }
 
-.c0 .Checkbox-input:disabled + .Checkbox-decoration {
+.c2:disabled + .c3 {
   background-color: #E2E6E3;
 }
 
-.c0 .Checkbox-input:disabled:hover {
+.c2:disabled:hover {
   cursor: not-allowed;
   border: 1px solid rgba(44,44,44,0.16);
 }
 
-.c0 .Checkbox-input:checked {
+.c2:checked {
   border: 1px solid #1785FB;
 }
 
-.c0 .Checkbox-input:checked + .Checkbox-decoration .Checkbox-check {
+.c2:checked + .c3 .c6 {
   -webkit-animation: gGaDtf 0.3s cubic-bezier(0.65,0,0.45,1) 300ms forwards;
   animation: gGaDtf 0.3s cubic-bezier(0.65,0,0.45,1) 300ms forwards;
 }
 
-.c0 .Checkbox-input:disabled:checked + .Checkbox-decoration .Checkbox-check {
+.c2:disabled:checked + .c3 .c6 {
   stroke: rgba(44,44,44,0.16);
 }
 
-.c0 .Checkbox-label {
-  margin-left: 4px;
-}
-
-<div
+<label
   className="c0"
+  htmlFor="test"
 >
   <div
-    className="Checkbox"
+    className="c1"
   >
     <input
       checked={true}
-      className="Checkbox-input"
+      className="c2"
       disabled={false}
+      id="test"
       name=""
       onChange={[Function]}
       type="checkbox"
     />
     <span
-      className="Checkbox-decoration"
+      className="c3 c4"
     >
       <svg
-        className="Checkbox-tip"
+        className="c5"
         height="12px"
         width="12px"
       >
@@ -130,7 +133,7 @@ exports[`render renders with label 1`] = `
           fill="none"
         >
           <polyline
-            className="Checkbox-check"
+            className="c6 c7"
             points="1.65093994 3.80255127 4.48919678 6.97192383 10.3794556 0.717346191"
           />
         </g>
@@ -138,11 +141,11 @@ exports[`render renders with label 1`] = `
     </span>
   </div>
   <div
-    className="Checkbox-label"
+    className="c8"
   >
     Hola
   </div>
-</div>
+</label>
 `;
 
 exports[`render renders without crashing 1`] = `
@@ -157,11 +160,11 @@ exports[`render renders without crashing 1`] = `
   align-items: center;
 }
 
-.c0 .Checkbox {
+.c1 {
   position: relative;
 }
 
-.c0 .Checkbox-decoration {
+.c4 {
   pointer-events: none;
   width: 16px;
   height: 16px;
@@ -173,17 +176,7 @@ exports[`render renders without crashing 1`] = `
   box-sizing: border-box;
 }
 
-.c0 .Checkbox-check {
-  stroke-width: 2;
-  stroke: #1785FB;
-  -webkit-transform-origin: 50% 50%;
-  -ms-transform-origin: 50% 50%;
-  transform-origin: 50% 50%;
-  stroke-dasharray: 48;
-  stroke-dashoffset: 48;
-}
-
-.c0 .Checkbox-tip {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -194,7 +187,17 @@ exports[`render renders without crashing 1`] = `
   transform: translateX(1px) translateY(3px);
 }
 
-.c0 .Checkbox-input {
+.c7 {
+  stroke-width: 2;
+  stroke: #1785FB;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+  stroke-dasharray: 48;
+  stroke-dashoffset: 48;
+}
+
+.c2 {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -211,63 +214,61 @@ exports[`render renders without crashing 1`] = `
   border: 1px solid rgba(44,44,44,0.16);
 }
 
-.c0 .Checkbox-input:focus {
+.c2:focus {
   outline: none;
 }
 
-.c0 .Checkbox-input:focus {
+.c2:focus {
   border: 2px solid #1785FB;
 }
 
-.c0 .Checkbox-input:hover {
+.c2:hover {
   border: 1px solid #47DB99;
 }
 
-.c0 .Checkbox-input:disabled + .Checkbox-decoration {
+.c2:disabled + .c3 {
   background-color: #E2E6E3;
 }
 
-.c0 .Checkbox-input:disabled:hover {
+.c2:disabled:hover {
   cursor: not-allowed;
   border: 1px solid rgba(44,44,44,0.16);
 }
 
-.c0 .Checkbox-input:checked {
+.c2:checked {
   border: 1px solid #1785FB;
 }
 
-.c0 .Checkbox-input:checked + .Checkbox-decoration .Checkbox-check {
+.c2:checked + .c3 .c6 {
   -webkit-animation: gGaDtf 0.3s cubic-bezier(0.65,0,0.45,1) 300ms forwards;
   animation: gGaDtf 0.3s cubic-bezier(0.65,0,0.45,1) 300ms forwards;
 }
 
-.c0 .Checkbox-input:disabled:checked + .Checkbox-decoration .Checkbox-check {
+.c2:disabled:checked + .c3 .c6 {
   stroke: rgba(44,44,44,0.16);
 }
 
-.c0 .Checkbox-label {
-  margin-left: 4px;
-}
-
-<div
+<label
   className="c0"
+  htmlFor="test"
 >
   <div
-    className="Checkbox"
+    className="c1"
   >
     <input
       checked={false}
-      className="Checkbox-input"
+      className="c2"
       disabled={false}
+      id="test"
       name=""
       onChange={[Function]}
       type="checkbox"
     />
     <span
-      className="Checkbox-decoration"
+      className="c3 c4"
     >
       <svg
-        className="Checkbox-tip"
+        className="c5"
         height="12px"
         width="12px"
       >
@@ -275,12 +276,150 @@ exports[`render renders without crashing 1`] = `
           fill="none"
         >
           <polyline
-            className="Checkbox-check"
+            className="c6 c7"
             points="1.65093994 3.80255127 4.48919678 6.97192383 10.3794556 0.717346191"
           />
         </g>
       </svg>
     </span>
   </div>
-</div>
+</label>
+`;
+
+exports[`render uses htmlFor for the label, and adds it as the input id 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1 {
+  position: relative;
+}
+
+.c4 {
+  pointer-events: none;
+  width: 16px;
+  height: 16px;
+  overflow: hidden;
+  border: 1px solid rgba(44,44,44,0.16);
+  border-radius: 3px;
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+}
+
+.c5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  -webkit-transform: translateX(1px) translateY(3px);
+  -ms-transform: translateX(1px) translateY(3px);
+  transform: translateX(1px) translateY(3px);
+}
+
+.c7 {
+  stroke-width: 2;
+  stroke: #1785FB;
+  -webkit-transform-origin: 50% 50%;
+  -ms-transform-origin: 50% 50%;
+  transform-origin: 50% 50%;
+  stroke-dasharray: 48;
+  stroke-dashoffset: 48;
+}
+
+.c2 {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: none;
+  width: 16px;
+  height: 16px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  border-radius: 3px;
+  border: 1px solid rgba(44,44,44,0.16);
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus {
+  border: 2px solid #1785FB;
+}
+
+.c2:hover {
+  border: 1px solid #47DB99;
+}
+
+.c2:disabled + .c3 {
+  background-color: #E2E6E3;
+}
+
+.c2:disabled:hover {
+  cursor: not-allowed;
+  border: 1px solid rgba(44,44,44,0.16);
+}
+
+.c2:checked {
+  border: 1px solid #1785FB;
+}
+
+.c2:checked + .c3 .c6 {
+  -webkit-animation: gGaDtf 0.3s cubic-bezier(0.65,0,0.45,1) 300ms forwards;
+  animation: gGaDtf 0.3s cubic-bezier(0.65,0,0.45,1) 300ms forwards;
+}
+
+.c2:disabled:checked + .c3 .c6 {
+  stroke: rgba(44,44,44,0.16);
+}
+
+<label
+  className="c0"
+  htmlFor="test"
+>
+  <div
+    className="c1"
+  >
+    <input
+      checked={false}
+      className="c2"
+      disabled={false}
+      id="test"
+      name=""
+      onChange={[Function]}
+      type="checkbox"
+    />
+    <span
+      className="c3 c4"
+    >
+      <svg
+        className="c5"
+        height="12px"
+        width="12px"
+      >
+        <g
+          fill="none"
+        >
+          <polyline
+            className="c6 c7"
+            points="1.65093994 3.80255127 4.48919678 6.97192383 10.3794556 0.717346191"
+          />
+        </g>
+      </svg>
+    </span>
+  </div>
+</label>
 `;

--- a/src/components/Checkbox/checkbox.js
+++ b/src/components/Checkbox/checkbox.js
@@ -10,90 +10,91 @@ const stroke = keyframes`
   }
 `;
 
-const StyleCheck = styled.div`
+const Wrapper = styled.label`
   display: flex;
   align-items: center;
+`;
 
-  .Checkbox {
-    position: relative;
-  }
+const StyledCheckbox = styled.div`
+  position: relative;
+`;
 
-  .Checkbox-decoration {
-    pointer-events: none;
-    width: 16px;
-    height: 16px;
-    overflow: hidden;
-    border: 1px solid ${rgba(colors.type01, 0.16)};
-    border-radius: 3px;
-    position: relative;
-    display: block;
-    box-sizing: border-box;
-  }
+const Label = styled.div`
+  margin-left: 4px;
+  font: 400 12px/20px 'Roboto';
+`;
 
-  .Checkbox-check {
-    stroke-width: 2;
-    stroke: ${colors.brand01};
-    transform-origin: 50% 50%;
-    stroke-dasharray: 48;
-    stroke-dashoffset: 48;
-  }
+const Decoration = styled.span`
+  pointer-events: none;
+  width: 16px;
+  height: 16px;
+  overflow: hidden;
+  border: 1px solid ${rgba(colors.type01, 0.16)};
+  border-radius: 3px;
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+`;
 
-  .Checkbox-tip {
-    display: flex;
-    position: relative;
-    transform: translateX(1px) translateY(3px);
-  }
+const Tip = styled.svg`
+  display: flex;
+  position: relative;
+  transform: translateX(1px) translateY(3px);
+`;
 
-  .Checkbox-input {
-    appearance: none;
-    background: none;
-    width: 16px;
-    height: 16px;
-    position: absolute;
-    top: 0;
-    left: 0;
-    cursor: pointer;
-    margin: 0;
-    padding: 0;
-    border-radius: 3px;
-    border: 1px solid ${rgba(colors.type01, 0.16)};
-  }
+const Check = styled.polyline`
+  stroke-width: 2;
+  stroke: ${colors.brand01};
+  transform-origin: 50% 50%;
+  stroke-dasharray: 48;
+  stroke-dashoffset: 48;
+`;
 
-  .Checkbox-input:focus {
+const CheckboxInput = styled.input`
+  appearance: none;
+  background: none;
+  width: 16px;
+  height: 16px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  border-radius: 3px;
+  border: 1px solid ${rgba(colors.type01, 0.16)};
+
+  &:focus {
     outline: none;
   }
 
-  .Checkbox-input:focus {
+  &:focus {
     border: 2px solid ${colors.brand01};
   }
 
-  .Checkbox-input:hover {
+  &:hover {
     border: 1px solid ${colors.brand03};
   }
 
-  .Checkbox-input:disabled + .Checkbox-decoration {
+  &:disabled + ${Decoration} {
     background-color: ${colors.ui03};
   }
 
-  .Checkbox-input:disabled:hover {
+  &:disabled:hover {
     cursor: not-allowed;
     border: 1px solid ${rgba(colors.type01, 0.16)};
   }
 
-  .Checkbox-input:checked {
+  &:checked {
     border: 1px solid ${colors.brand01};
   }
 
-  .Checkbox-input:checked + .Checkbox-decoration .Checkbox-check {
+  &:checked + ${Decoration} ${Check} {
     animation: ${stroke} 0.3s cubic-bezier(0.65, 0, 0.45, 1) 300ms forwards;
   }
 
-  .Checkbox-input:disabled:checked + .Checkbox-decoration .Checkbox-check {
+  &:disabled:checked + ${Decoration} ${Check} {
     stroke: ${rgba(colors.type01, 0.16)};
-  }
-
-  .Checkbox-label {
-    margin-left: 4px;
   }
 `;
 
@@ -110,67 +111,61 @@ class Checkbox extends Component {
 
   clickHandler = (e) => {
     const { onChange, disabled } = this.props;
-    !disabled &&
-      this.setState(
-        (state) => {
-          return {
-            ...state,
-            checked: !state.checked
-          };
-        },
-        () => {
-          onChange && onChange(this.state);
-        }
-      );
+
+    if (disabled) return;
+
+    this.setState(
+      (state) => ({ ...state, checked: !state.checked }),
+      () => onChange && onChange(this.state)
+    );
   };
 
   render() {
-    const { children, name, as, disabled } = this.props;
-
+    const { children, name, as, disabled, htmlFor } = this.props;
     const { checked } = this.state;
-    const Wrapper = as !== 'div' ? StyleCheck.withComponent(as) : StyleCheck;
+    const WrapperComponent = as !== 'div' ? Wrapper.withComponent(as) : Wrapper;
+
     return (
-      <Wrapper>
-        <div className="Checkbox">
-          <input
-            className="Checkbox-input"
+      <Wrapper htmlFor={htmlFor}>
+        <StyledCheckbox>
+          <CheckboxInput
+            id={htmlFor}
             type="checkbox"
             name={name}
             onChange={this.clickHandler}
             disabled={disabled}
             checked={checked}
           />
-          <span className="Checkbox-decoration">
-            <svg width="12px" height="12px" className="Checkbox-tip">
+          <Decoration>
+            <Tip width="12px" height="12px">
               <g fill="none">
-                <polyline
-                  className="Checkbox-check"
-                  points="1.65093994 3.80255127 4.48919678 6.97192383 10.3794556 0.717346191"
-                />
+                <Check points="1.65093994 3.80255127 4.48919678 6.97192383 10.3794556 0.717346191" />
               </g>
-            </svg>
-          </span>
-        </div>
-        {children && <div className="Checkbox-label">{children}</div>}
+            </Tip>
+          </Decoration>
+        </StyledCheckbox>
+
+        {children && <Label>{children}</Label>}
       </Wrapper>
     );
   }
 }
 
 Checkbox.defaultProps = {
-  name: '',
   as: 'div',
-  onChange: (e) => {},
+  checked: false,
   disabled: false,
-  checked: false
+  name: '',
+  onChange: () => {},
 };
 
 Checkbox.propTypes = {
-  name: PropTypes.string,
-  as: PropTypes.oneOf(['div', 'li', 'span']),
-  onChange: PropTypes.func,
+  as: PropTypes.string,
+  checked: PropTypes.bool,
   disabled: PropTypes.bool,
-  checked: PropTypes.bool
+  htmlFor: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  onChange: PropTypes.func,
 };
 
 export default Checkbox;

--- a/src/components/Checkbox/checkbox.stories.js
+++ b/src/components/Checkbox/checkbox.stories.js
@@ -7,27 +7,50 @@ storiesOf('Checkbox', module)
   .add('Default', () => (
     <div>
       <h3 className="header">Default</h3>
-      <Checkbox />
+      <Checkbox htmlFor="default" />
+
+      <h3 className="header">With label</h3>
+      <Checkbox htmlFor="with-label">
+        Hello there
+      </Checkbox>
 
       <h3 className="header">Checked</h3>
-      <Checkbox name="three" checked>Hola</Checkbox>
-
-      <h3 className="header">Disabled</h3>
-      <Checkbox disabled>Disabled</Checkbox>
+      <Checkbox htmlFor="checked" checked>
+        Hello there
+      </Checkbox>
     </div>
   ))
   .add('Disabled', () => (
     <div>
-      <h3 className="header">Disabled</h3>
-      <Checkbox />
+      <h3 className="header">Default</h3>
+      <Checkbox htmlFor="disabled" disabled />
+
+      <h3 className="header">With label</h3>
+      <Checkbox htmlFor="with-label" disabled>
+        Hello there
+      </Checkbox>
 
       <h3 className="header">Checked</h3>
-      <Checkbox name="three" disabled checked>Hola</Checkbox>
+      <Checkbox htmlFor="checked" disabled checked>
+        Hello there
+      </Checkbox>
     </div>
   ))
   .add('With event', () => (
     <div>
       <h3 className="header">Default</h3>
-      <Checkbox checked onChange={state => console.log(state)}>Option</Checkbox>
+      <Checkbox htmlFor="event" onChange={action('onChange')}>
+        Click me!
+      </Checkbox>
+
+      <h3 className="header">Checked</h3>
+      <Checkbox htmlFor="event" onChange={action('onChange')} checked>
+        Click me!
+      </Checkbox>
+
+      <h3 className="header">Disabled</h3>
+      <Checkbox htmlFor="event" onChange={action('onChange')} disabled>
+        Click me!
+      </Checkbox>
     </div>
   ))

--- a/src/components/Checkbox/checkbox.test.js
+++ b/src/components/Checkbox/checkbox.test.js
@@ -5,14 +5,14 @@ import { mount } from 'enzyme';
 
 describe('render', () => {
   it('renders without crashing', () => {
-    const component = renderer.create(<Checkbox value="wadus" />);
+    const component = renderer.create(<Checkbox htmlFor="test" value="wadus" />);
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('renders with label', () => {
     const component = renderer.create(
-      <Checkbox value="wadus" checked>
+      <Checkbox htmlFor="test" value="wadus" checked>
         Hola
       </Checkbox>
     );
@@ -20,10 +20,17 @@ describe('render', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('uses htmlFor for the label, and adds it as the input id', () => {
+    const component = renderer.create(<Checkbox htmlFor="test" label="Rick" />);
+    const tree = component.toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
   it('onChange', () => {
     const spy = jest.fn();
     const component = mount(
-      <Checkbox value="wadus" onChange={spy}>
+      <Checkbox htmlFor="test" value="wadus" onChange={spy}>
         Hola
       </Checkbox>
     );


### PR DESCRIPTION
### Description
We were using `classNames` under a styled component wrapper, this PR moves every element into it's own styled component.