### PR TITLE
Add overrides to <Collapsible />

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add `overrides` prop to `<Collapsible />` (#28).
+
 ### Changes
 - Change `<Histogram />` data input format (#27).
 

--- a/docs/components/collapsible.md
+++ b/docs/components/collapsible.md
@@ -25,6 +25,29 @@ Choose if initially is open. By default is `true`.
 </Collapsible>
 ```
 
+#### **overrides** (object)
+
+It allows us to override the styles of the component. It needs an object where the key is the component name, and the value the styles we want to override.
+
+```react
+<Collapsible overrides={{
+  Collapsible: css`
+    background: #EFEFEF;
+    width: 400px;
+  `,
+  'Collapsible.Header': css`
+    background: #CCC;
+    padding: 1rem;
+  `,
+  'Collapsible.Content': css`
+    padding: 1rem;
+  `,
+}}>
+  <Collapsible.Header>Header</Collapsible.Header>
+  <Collapsible.Content>Content</Collapsible.Content>
+</Collapsible>
+```
+
 #### **onChange** (function)
 
 Callback to be called when the collapsible toggles..

--- a/docs/components/collapsible.md
+++ b/docs/components/collapsible.md
@@ -31,15 +31,15 @@ It allows us to override the styles of the component. It needs an object where t
 
 ```react
 <Collapsible overrides={{
-  Collapsible: css`
+  Collapsible: `
     background: #EFEFEF;
     width: 400px;
   `,
-  'Collapsible.Header': css`
+  'Collapsible.Header': `
     background: #CCC;
     padding: 1rem;
   `,
-  'Collapsible.Content': css`
+  'Collapsible.Content': `
     padding: 1rem;
   `,
 }}>

--- a/src/components/Collapsible/__snapshots__/collapsible.test.js.snap
+++ b/src/components/Collapsible/__snapshots__/collapsible.test.js.snap
@@ -21,7 +21,6 @@ exports[`render renders without crashing 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  margin-bottom: 12px;
 }
 
 .c0 button {
@@ -40,7 +39,13 @@ exports[`render renders without crashing 1`] = `
   outline: none;
 }
 
-<div>
+.c2 {
+  margin-top: 12px;
+}
+
+<div
+  className=""
+>
   <div
     className="c0"
   >
@@ -61,6 +66,10 @@ exports[`render renders without crashing 1`] = `
       </svg>
     </button>
   </div>
-  Content
+  <div
+    className="c2"
+  >
+    Content
+  </div>
 </div>
 `;

--- a/src/components/Collapsible/collapsible.js
+++ b/src/components/Collapsible/collapsible.js
@@ -1,12 +1,19 @@
 import React, { Component, Children } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { isComponentOfType } from '../../utils';
+import { isComponentOfType, withOverride } from '../../utils';
+import { theme } from '../../constants';
 import Icon from '../Icon/icon';
+
+const Wrapper = styled.div`
+  ${withOverride('Collapsible')};
+`;
+Wrapper.defaultProps = {
+  theme,
+};
 
 const Header = styled.div`
   display: flex;
-  margin-bottom: 12px;
 
   button {
     border: 0;
@@ -17,18 +24,28 @@ const Header = styled.div`
     align-items: center;
     outline: none;
   }
-`;
-Header.displayName = 'Collapsible.Header';
 
-const Content = ({ children }) => children;
-Content.displayName = 'Collapsible.Content';
+  ${withOverride('Collapsible.Header')};
+`;
+Header.defaultProps = {
+  theme,
+};
+
+const Content = styled.div`
+  margin-top: 12px;
+
+  ${withOverride('Collapsible.Content')};
+`;
+Content.defaultProps = {
+  theme,
+};
 
 class Collapsible extends Component {
   static Header = Header;
   static Content = Content;
 
   state = {
-    open: !!this.props.open,
+    open: this.props.open,
   };
 
   componentWillReceiveProps(nextProps) {
@@ -41,35 +58,36 @@ class Collapsible extends Component {
     const { onChange } = this.props;
 
     this.setState(
-      state => ({
-        ...state,
-        open: !state.open,
-      }),
+      prevState => ({ open: !prevState.open }),
       () => onChange && onChange(this.state)
     );
   };
 
   render() {
     const { open } = this.state;
-    const { children } = this.props;
+    const { children, overrides } = this.props;
 
     return (
-      <div>
+      <Wrapper overrides={overrides}>
         {Children.map(children, child => {
+          const childProps = { ...child.props, overrides };
+
           if (isComponentOfType(Collapsible.Header, child)) {
-            return (
-              <Collapsible.Header>
+            return React.cloneElement(
+              child,
+              childProps,
+              <React.Fragment>
                 <div>{child.props.children}</div>
                 <button onClick={() => this.toggle()} >
                   <Icon icon={open ? 'chevron_up' : 'chevron_down'} />
                 </button>
-              </Collapsible.Header>
+              </React.Fragment>
             );
           } else if (isComponentOfType(Collapsible.Content, child) && open) {
-            return child;
+            return React.cloneElement(child, childProps);
           }
         })}
-      </div>
+      </Wrapper>
     );
   }
 }
@@ -82,6 +100,7 @@ Collapsible.propTypes = {
   children: PropTypes.node,
   onChange: PropTypes.func,
   open: PropTypes.bool,
+  overrides: PropTypes.object,
 };
 
 export default Collapsible;

--- a/src/components/Collapsible/collapsible.stories.js
+++ b/src/components/Collapsible/collapsible.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { css } from 'styled-components';
 import { storiesOf } from '@storybook/react';
 import Collapsible from '../Collapsible/collapsible';
 import Badge from '../Badge/badge';
@@ -18,4 +19,33 @@ storiesOf('Collapsible', module)
         </Collapsible.Content>
       </Collapsible>
     </div>
-  ));
+  ))
+  .add('With overrides', () => {
+    const overrides = {
+      Collapsible: css`
+        background: ${props => props.theme.ui04};
+        width: 400px;
+      `,
+      'Collapsible.Header': css`
+        background: ${props => props.theme.brand03};
+        padding: 1rem;
+      `,
+      'Collapsible.Content': css`
+        padding: 1rem;
+      `,
+    };
+
+    return (
+      <div style={{ maxWidth: '200px' }}>
+        <Collapsible overrides={overrides}>
+          <Collapsible.Header>
+            <Subheader>Global index</Subheader>
+          </Collapsible.Header>
+          <Collapsible.Content>
+            <Badge color="#B4E0FA">Store 1</Badge>
+            <Text as="div">Some fanzy text here</Text>
+          </Collapsible.Content>
+        </Collapsible>
+      </div>
+    );
+  });

--- a/src/components/Collapsible/collapsible.test.js
+++ b/src/components/Collapsible/collapsible.test.js
@@ -38,4 +38,28 @@ describe('render', () => {
 
     expect(spy).toHaveBeenCalled();
   });
+
+  it('renders with overrides', () => {
+    const overrides = {
+      Collapsible: `
+        background: #CCC;
+        width: 400px;
+      `,
+      'Collapsible.Header': `
+        background: #AAA;
+        padding: 1rem;
+      `,
+      'Collapsible.Content': `
+        padding: 1rem;
+      `,
+    };
+
+    const component = shallow(
+      <Collapsible open overrides={overrides}>
+        <Collapsible.Header>Header</Collapsible.Header>
+        <Collapsible.Content>Content</Collapsible.Content>
+      </Collapsible>
+    );
+    expect(component.find(Collapsible.Content).length).toBe(1);
+  });
 });

--- a/src/utils/getObjectValue.js
+++ b/src/utils/getObjectValue.js
@@ -1,0 +1,11 @@
+/**
+  * Gets the value at path of object. If the resolved value is undefined, the defaultValue is returned in its place.
+  * @param {Object} object The object to query.
+  * @param {String} path The path of the property to get.
+  * @param {Any} defaultValue The value returned for undefined resolved values.
+  * @return {Any} Returns the resolved value.
+  */
+export default (object, path, defaultValue) => {
+  const value = path.reduce((a, b) => (a || {})[b], object);
+  return value || defaultValue;
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -10,3 +10,4 @@ export { default as readableNumber } from './readable-number';
 export { default as truncate } from './truncate';
 export { default as isComponentOfType } from './is-component-of-type';
 export { default as nodeMock } from './nodeMock';
+export { default as withOverride } from './withOverride';

--- a/src/utils/withOverride.js
+++ b/src/utils/withOverride.js
@@ -1,0 +1,5 @@
+import getObjectValue from './getObjectValue';
+
+export default function withOverride(key) {
+  return props => getObjectValue(props, ['overrides', key]);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR adds an `overrides` prop to the `<Collapsible />` component to be able to override styles.

Example:

```
const overrides = {
  Collapsible: `
    background: #CCC;
    width: 400px;
  `,
  'Collapsible.Header': `
    background: #AAA;
    padding: 1rem;
  `,
  'Collapsible.Content': `
    padding: 1rem;
  `,
};

return (
  <Collapsible overrides={overrides}>
    <Collapsible.Header>Header</Collapsible.Header>
    <Collapsible.Content>Content</Collapsible.Content>
  </Collapsible>
)
```