### PR TITLE
Web Components testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   "scripts": {
     "build": "lerna run --parallel build",
     "dev": "lerna run --parallel dev",
-    "lint:fix": "lerna run lint:fix",
+    "test:components": "lerna exec --scope @carto/airship-components -- npm run test",
+    "test:components:watch": "lerna exec -- npm run test:watch",
     "lint": "lerna run lint",
+    "lint:fix": "lerna run lint:fix",
     "postinstall": "lerna bootstrap --hoist",
     "serve": "lerna run --parallel serve",
     "test:watch": "lerna run --parallel test:watch",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "lerna run --parallel build",
     "dev": "lerna run --parallel dev",
     "test:components": "lerna exec --scope @carto/airship-components -- npm run test",
-    "test:components:watch": "lerna exec -- npm run test:watch",
+    "test:components:watch": "lerna exec --scope @carto/airship-components -- npm run test:watch",
     "lint": "lerna run lint",
     "lint:fix": "lerna run lint:fix",
     "postinstall": "lerna bootstrap --hoist",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/CartoDB/airship",
   "jest": {
     "transform": {
-      "^.+\\.(ts|tsx)$": "<rootDir>/node_modules/@stencil/core/testing/jest.preprocessor.js"
+      "^.+\\.(ts|tsx)$": "../../node_modules/@stencil/core/testing/jest.preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
     "moduleFileExtensions": [

--- a/packages/components/src/components/as-switch/as-switch.spec.ts
+++ b/packages/components/src/components/as-switch/as-switch.spec.ts
@@ -2,33 +2,30 @@ import { TestWindow } from '@stencil/core/testing';
 import { Switch } from './as-switch';
 
 describe('as-switch', () => {
-  let element: HTMLSwitchElement;
-  let testWindow: TestWindow;
-
-  beforeEach(async () => {
-    testWindow = new TestWindow();
-    element = await testWindow.load({
-      components: [Switch],
-      html: '<as-switch></as-switch>'
-    });
-  });
-
   it('should build', () => {
     expect(new Switch()).toBeTruthy();
   });
 
-  describe('Rendering', () => {
-
-  });
-
   describe('Behaviour', () => {
-    it('should toggle when the switch is clicked', async () => {
-      expect(element.querySelector('input').checked).toBeFalsy();
-      element.click();
-      await testWindow.flush();
+    let element: HTMLSwitchElement;
+    let testWindow: TestWindow;
 
-      console.log(element.querySelector('input').checked);
-      expect(element.querySelector('input').checked).toBeTruthy();
+    beforeEach(async () => {
+      testWindow = new TestWindow();
+      element = await testWindow.load({
+        components: [Switch],
+        html: '<as-switch></as-switch>'
+      });
+    });
+
+    it('should emit an event with current status when component toggles', () => {
+      const spy = jest.fn();
+      element.addEventListener('onToggle', spy);
+
+      element.querySelector('input').click();
+
+      expect(spy).toHaveBeenCalled();
+      expect(spy.mock.calls[0][0].detail).toBe(true);
     });
   });
 });

--- a/packages/components/src/components/as-switch/as-switch.spec.ts
+++ b/packages/components/src/components/as-switch/as-switch.spec.ts
@@ -2,42 +2,33 @@ import { TestWindow } from '@stencil/core/testing';
 import { Switch } from './as-switch';
 
 describe('as-switch', () => {
+  let element: HTMLSwitchElement;
+  let testWindow: TestWindow;
+
+  beforeEach(async () => {
+    testWindow = new TestWindow();
+    element = await testWindow.load({
+      components: [Switch],
+      html: '<as-switch></as-switch>'
+    });
+  });
+
   it('should build', () => {
     expect(new Switch()).toBeTruthy();
   });
 
-  describe('rendering', () => {
-    let element: HTMLMyComponentElement;
-    let testWindow: TestWindow;
-    beforeEach(async () => {
-      testWindow = new TestWindow();
-      element = await testWindow.load({
-        components: [Switch],
-        html: '<as-switch></as-switch>'
-      });
-    });
+  describe('Rendering', () => {
 
-    it('should work without parameters', () => {
-      expect(element.textContent.trim()).toEqual('Hello, World! I\'m');
-    });
+  });
 
-    it('should work with a first name', async () => {
-      element.first = 'Peter';
+  describe('Behaviour', () => {
+    it('should toggle when the switch is clicked', async () => {
+      expect(element.querySelector('input').checked).toBeFalsy();
+      element.click();
       await testWindow.flush();
-      expect(element.textContent.trim()).toEqual('Hello, World! I\'m Peter');
-    });
 
-    it('should work with a last name', async () => {
-      element.last = 'Parker';
-      await testWindow.flush();
-      expect(element.textContent.trim()).toEqual('Hello, World! I\'m  Parker');
-    });
-
-    it('should work with both a first and a last name', async () => {
-      element.first = 'Peter';
-      element.last = 'Parker';
-      await testWindow.flush();
-      expect(element.textContent.trim()).toEqual('Hello, World! I\'m Peter Parker');
+      console.log(element.querySelector('input').checked);
+      expect(element.querySelector('input').checked).toBeTruthy();
     });
   });
 });

--- a/packages/components/src/components/as-switch/as-switch.tsx
+++ b/packages/components/src/components/as-switch/as-switch.tsx
@@ -1,4 +1,4 @@
-import { Component } from '@stencil/core';
+import { Component, Event, EventEmitter } from '@stencil/core';
 
 @Component({
   tag: 'as-switch',
@@ -6,13 +6,19 @@ import { Component } from '@stencil/core';
   shadow: false
 })
 export class Switch {
+  @Event() onToggle: EventEmitter;
+
   render() {
     return (
       <label class="switch">
-        <input type="checkbox" />
+        <input type="checkbox" onChange={(event: UIEvent) => this.onInputChanged(event)}/>
         <span class="slider"></span>
       </label>
     );
   }
-}
 
+  onInputChanged(event) {
+    const currentState = event.target.checked;
+    this.onToggle.emit(currentState);
+  }
+}


### PR DESCRIPTION
Related to https://github.com/CartoDB/airship/issues/51

This PR sets up component testing with Jest. It was already configured in Stencil, but as we use multiple packages I needed to change the path of a file.

There are two new npm scripts:
- `test:components`: which launches Web Component tests only, and check them once.

- `test:components:watch`: which launches Web Component tests only, but it passes the test suite every time a file is modified. There's a mini GUI with multiple options, but by default, it only runs the tests compelling to the files which its code has been modified since last commmit.