### PR TITLE
Add link to documentation on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![CircleCI](https://circleci.com/gh/CartoDB/airship/tree/master.svg?style=svg)](https://circleci.com/gh/CartoDB/airship/tree/master)
 
-There are two npm packages for easier use:
+There are three npm packages for easier use:
 
 
 | module | status | version | description |
@@ -11,6 +11,10 @@ There are two npm packages for easier use:
 |  [airship-style](https://www.npmjs.com/package/@carto/airship-style) | ![status](https://img.shields.io/badge/status-in%20progress-orange.svg) | [![npm version](https://badge.fury.io/js/%40carto%2Fairship-style.svg)](https://badge.fury.io/js/%40carto%2Fairship-style)| A complete CSS framework to build location intelligence apps. |
 |  [airship-components](https://www.npmjs.com/package/@carto/airship-components) | ![status](https://img.shields.io/badge/status-in%20progress-orange.svg) | [![npm version](https://badge.fury.io/js/%40carto%2Fairship-components.svg)](https://badge.fury.io/js/%40carto%2Fairship-components) | Web components for Location Intelligence apps. |
 |  [airship-icons](https://www.npmjs.com/package/@carto/airship-icons) | ![status](https://img.shields.io/badge/status-in%20progress-orange.svg) | [![npm version](https://badge.fury.io/js/%40carto%2Fairship-icons.svg)](https://badge.fury.io/js/%40carto%2Fairship-icons) | High quality icons set |
+
+## Documentation
+
+The library is documented with [Catalog](https://www.catalog.style), check out our [documentation website](https://carto-airship.netlify.com/#/)
 
 ## ⚠️ WARNING ⚠️
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are three npm packages for easier use:
 
 ## Documentation
 
-The library is documented with [Catalog](https://www.catalog.style), check out our [documentation website](https://carto-airship.netlify.com/#/)
+Check out our [documentation website](https://carto-airship.netlify.com/#/)
 
 ## ⚠️ WARNING ⚠️
 


### PR DESCRIPTION
#172

We're linking on the repo description to the website, where there's a lin to catalog, but this adds it to the README as well.