### PR TITLE
Fix some histogram issues

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,6 +66,7 @@
     "d3-array": "^1.2.1",
     "d3-axis": "^1.0.8",
     "d3-brush": "^1.0.4",
+    "d3-format": "^1.3.2",
     "d3-scale": "^2.1.0",
     "d3-selection": "^1.3.0",
     "d3-transition": "^1.1.1"

--- a/packages/components/src/components/as-histogram-widget/__snapshots__/as-histogram-widget.spec.ts.snap
+++ b/packages/components/src/components/as-histogram-widget/__snapshots__/as-histogram-widget.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`as-histogram-widget Rendering should not render header when showHeader 
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       />
       <g
         class="xAxis"
@@ -32,7 +32,7 @@ exports[`as-histogram-widget Rendering should not render header when showHeader 
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(40, 140)"
+        transform="translate(35, 140)"
       >
         <g
           class="tick"
@@ -49,7 +49,7 @@ exports[`as-histogram-widget Rendering should not render header when showHeader 
         </g>
       </g>
       <g
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       />
       <g
         class="brush"
@@ -62,7 +62,7 @@ exports[`as-histogram-widget Rendering should not render header when showHeader 
           height="125"
           pointer-events="all"
           width="205"
-          x="40"
+          x="35"
           y="15"
         />
         <rect
@@ -125,13 +125,13 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
   class="hydrated"
 >
   
-  <h3
+  <h2
     class="as-histogram-widget__header"
   >
     
-  </h3>
+  </h2>
   <p
-    class="as-histogram-widget__description"
+    class="as-histogram-widget__description as-body"
   >
     
   </p>
@@ -153,7 +153,7 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       >
         <g
           class="tick"
@@ -247,7 +247,7 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(40, 140)"
+        transform="translate(35, 140)"
       >
         <g
           class="tick"
@@ -316,7 +316,7 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         </g>
       </g>
       <g
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       >
         <rect
           class="bar"
@@ -362,7 +362,7 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
           height="125"
           pointer-events="all"
           width="205"
-          x="40"
+          x="35"
           y="15"
         />
         <rect
@@ -429,13 +429,13 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
   class="hydrated"
 >
   
-  <h3
+  <h2
     class="as-histogram-widget__header"
   >
     
-  </h3>
+  </h2>
   <p
-    class="as-histogram-widget__description"
+    class="as-histogram-widget__description as-body"
   >
     
   </p>
@@ -457,7 +457,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       >
         <g
           class="tick"
@@ -551,7 +551,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(40, 140)"
+        transform="translate(35, 140)"
       >
         <g
           class="tick"
@@ -620,7 +620,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         </g>
       </g>
       <g
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       >
         <rect
           class="bar"
@@ -666,7 +666,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           height="125"
           pointer-events="all"
           width="205"
-          x="40"
+          x="35"
           y="15"
         />
         <rect
@@ -679,7 +679,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           stroke="#fff"
           style=""
           width="102.5"
-          x="40"
+          x="35"
           y="15"
         />
         <rect
@@ -688,7 +688,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           height="130"
           style=""
           width="5"
-          x="140"
+          x="135"
           y="12.5"
         />
         <rect
@@ -697,7 +697,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           height="130"
           style=""
           width="5"
-          x="37.5"
+          x="32.5"
           y="12.5"
         />
         <rect
@@ -708,7 +708,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           rx="100"
           ry="100"
           style="opacity: 1;"
-          transform="translate(32.5,132.5)"
+          transform="translate(27.5,132.5)"
           width="15"
         />
         <rect
@@ -719,7 +719,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           rx="100"
           ry="100"
           style="opacity: 1;"
-          transform="translate(135,132.5)"
+          transform="translate(130,132.5)"
           width="15"
         />
         <line
@@ -728,8 +728,8 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           stroke="#47DB99"
           stroke-width="4"
           style="opacity: 1;"
-          x1="40"
-          x2="142.5"
+          x1="35"
+          x2="137.5"
           y1="140"
           y2="140"
         />
@@ -745,13 +745,13 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
   class="hydrated"
 >
   
-  <h3
+  <h2
     class="as-histogram-widget__header"
   >
     Histogram Widget Example
-  </h3>
+  </h2>
   <p
-    class="as-histogram-widget__description"
+    class="as-histogram-widget__description as-body"
   >
     Description for Histogram Widget
   </p>
@@ -773,7 +773,7 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       >
         <g
           class="tick"
@@ -867,7 +867,7 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(40, 140)"
+        transform="translate(35, 140)"
       >
         <g
           class="tick"
@@ -936,7 +936,7 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         </g>
       </g>
       <g
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       >
         <rect
           class="bar"
@@ -982,7 +982,7 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
           height="125"
           pointer-events="all"
           width="205"
-          x="40"
+          x="35"
           y="15"
         />
         <rect
@@ -1049,13 +1049,13 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
   class="hydrated"
 >
   
-  <h3
+  <h2
     class="as-histogram-widget__header"
   >
     
-  </h3>
+  </h2>
   <p
-    class="as-histogram-widget__description"
+    class="as-histogram-widget__description as-body"
   >
     
   </p>
@@ -1077,7 +1077,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       >
         <g
           class="tick"
@@ -1171,7 +1171,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(40, 140)"
+        transform="translate(35, 140)"
       >
         <g
           class="tick"
@@ -1240,7 +1240,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         </g>
       </g>
       <g
-        transform="translate(40, 15)"
+        transform="translate(35, 15)"
       >
         <rect
           class="bar"
@@ -1286,7 +1286,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           height="125"
           pointer-events="all"
           width="205"
-          x="40"
+          x="35"
           y="15"
         />
         <rect
@@ -1299,7 +1299,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           stroke="#fff"
           style=""
           width="102.5"
-          x="40"
+          x="35"
           y="15"
         />
         <rect
@@ -1308,7 +1308,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           height="130"
           style=""
           width="5"
-          x="140"
+          x="135"
           y="12.5"
         />
         <rect
@@ -1317,7 +1317,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           height="130"
           style=""
           width="5"
-          x="37.5"
+          x="32.5"
           y="12.5"
         />
         <rect
@@ -1328,7 +1328,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           rx="100"
           ry="100"
           style="opacity: 1;"
-          transform="translate(32.5,132.5)"
+          transform="translate(27.5,132.5)"
           width="15"
         />
         <rect
@@ -1339,7 +1339,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           rx="100"
           ry="100"
           style="opacity: 1;"
-          transform="translate(135,132.5)"
+          transform="translate(130,132.5)"
           width="15"
         />
         <line
@@ -1348,8 +1348,8 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           stroke="#47DB99"
           stroke-width="4"
           style="opacity: 1;"
-          x1="40"
-          x2="142.5"
+          x1="35"
+          x2="137.5"
           y1="140"
           y2="140"
         />

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.html
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.html
@@ -5,9 +5,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
     <title>Airship</title>
-    <link rel="stylesheet" href="/dist/core/core.css">
+    <link rel="stylesheet" href="/dist/airship.css">
     <script src="/build/airship.js"></script>
-    <script src="https://d3js.org/d3-format.v1.min.js"></script>
   </head>
 
   <body>

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.html
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.html
@@ -7,6 +7,7 @@
     <title>Airship</title>
     <link rel="stylesheet" href="/dist/core/core.css">
     <script src="/build/airship.js"></script>
+    <script src="https://d3js.org/d3-format.v1.min.js"></script>
   </head>
 
   <body>
@@ -21,10 +22,11 @@
     <script>
       var histogramWidget = document.querySelector('as-histogram-widget');
       histogramWidget.data = [
-        { start: 0, end: 10, value: 5 },
-        { start: 10, end: 20, value: 10 },
-        { start: 20, end: 30, value: 15 },
-        { start: 30, end: 40, value: 20 },
+        { start: 0, end: 10, value: 1050 },
+        { start: 10, end: 20, value: 1150 },
+        { start: 20, end: 30, value: 1250 },
+        { start: 30, end: 40, value: 1350 },
+        { start: 40, end: 50, value: 2000 },
       ];
     </script>
   </body>

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -29,6 +29,7 @@ as-histogram-widget {
 
   svg {
     display: block;
+    overflow: visible;
 
     .brush {
       .selection {

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -6,11 +6,12 @@ as-histogram-widget {
   background: var(--histogram-widget--background-color, $color-ui-01);
 
   .as-histogram-widget__header {
+    margin: 0;
     font: $font-subheader;
   }
 
   .as-histogram-widget__description {
-    font: $font-body;
+    color: var(--description--color, $color-type-02);
   }
 
   .as-histogram-widget__wrapper {

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -2,6 +2,7 @@ import { Component, Event, EventEmitter, Method, Prop, State, Watch } from '@ste
 import { max } from 'd3-array';
 import { Axis, axisBottom, axisLeft } from 'd3-axis';
 import { BrushBehavior, brushX } from 'd3-brush';
+import { format } from 'd3-format';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
 import {
   BaseType,
@@ -431,8 +432,9 @@ export class HistogramWidget {
 
     this.yAxis = axisLeft(this.yScale)
       .tickSize(-WIDTH)
-      .ticks(5, ',.0s')
-      .tickPadding(10);
+      .ticks(5)
+      .tickPadding(10)
+      .tickFormat(format('.2~s'));
 
     this.yAxisSelection = this.container
       .append('g')

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -22,7 +22,7 @@ const HEIGHT = 125;
 const BARS_SEPARATION = 1;
 const MARGIN = {
   BOTTOM: 15,
-  LEFT: 40,
+  LEFT: 35,
   RIGHT: 3,
   TOP: 15,
 };
@@ -576,8 +576,8 @@ export class HistogramWidget {
     }
 
     return [
-      <h3 class='as-histogram-widget__header'>{this.heading}</h3>,
-      <p class='as-histogram-widget__description'>{this.description}</p>,
+      <h2 class='as-histogram-widget__header'>{this.heading}</h2>,
+      <p class='as-histogram-widget__description as-body'>{this.description}</p>,
     ];
   }
 

--- a/packages/styles/src/buttons/buttons.scss
+++ b/packages/styles/src/buttons/buttons.scss
@@ -40,7 +40,6 @@
     background-color: var(--as-color-ui-02, #{$color-ui-02});
   }
 
-  &:enabled:focus,
   &:enabled:active {
     background-color: var(--as-color-ui-03, #{$color-ui-03});
   }
@@ -53,7 +52,6 @@
       background-color: var(--as-button-primary-color-focus, darken($color-primary, 20%));
     }
 
-    &:enabled:focus,
     &:enabled:active {
       background-color: var(--as-button-primary-color-focus, darken($color-primary, 40%));
     }
@@ -68,7 +66,6 @@
       background-color: var(--as-button-secondary-color-focus, darken($color-ui-01, 10%));
     }
 
-    &:enabled:focus,
     &:enabled:active {
       background-color: var(--as-button-secondary-color-active, darken($color-ui-01, 10%));
     }
@@ -97,7 +94,6 @@ a.as-btn {
     background-color: var(--as-button-color-focus, #{$color-ui-02});
   }
 
-  &:focus,
   &:active {
     background-color: var(--as-button-color-focus, #{$color-ui-03});
   }
@@ -108,7 +104,6 @@ a.as-btn.as-btn--primary {
     background-color: var(--as-button-primary-color-focus, darken($color-primary, 20%));
   }
 
-  &:focus,
   &:active {
     background-color: var(--as-button-primary-color-focus, darken($color-primary, 40%));
   }
@@ -119,7 +114,6 @@ a.as-btn.as-btn--secondary {
     background-color: var(--as-button-secondary-color-active, darken($color-ui-01, 10%));
   }
 
-  &:focus,
   &:active {
     background-color: var(--as-button-secondary-color-active, darken($color-ui-01, 12%));
   }


### PR DESCRIPTION
#205
---

I fixed two problems, the selector overflowed a few pixels on the right, so I made it visible, and I've added d3-format as an explicit dependency to fine tune the axis format.

![image](https://user-images.githubusercontent.com/446970/44650483-0fa7e100-a9e7-11e8-972b-119e577f4967.png)

The `0k` was driving me insane :upside_down_face:, it seems like d3-axis has some issues when specifying a string format instead of the d3-format function.

