### PR TITLE
Allow sidebars to be in a different DOM order while maintaining position

### DIFF
--- a/examples/layouts/common/tabs.js
+++ b/examples/layouts/common/tabs.js
@@ -54,14 +54,14 @@ function showBottomPanel(visible) {
   showPanel('as-bottom-bar', visible);
 }
 
-function showPanel(className, visible) {
+function showPanel(className, visible, visibleClassName) {
   var element = document.querySelector(`.${className}`)
 
   if (!element) {
     return;
   }
 
-  var visibleClass = className + '--visible';
+  var visibleClass = visibleClassName || (className + '--visible');
   visible
     ? element.classList.add(visibleClass)
     : element.classList.remove(visibleClass);

--- a/examples/layouts/common/tabs.js
+++ b/examples/layouts/common/tabs.js
@@ -39,11 +39,11 @@ function showBottom(event) {
 }
 
 function showLeftPanel(visible) {
-  showPanel('as-sidebar--left', visible);
+  showPanel('as-sidebar--left', visible, 'as-sidebar--visible');
 }
 
 function showRightPanel(visible) {
-  showPanel('as-sidebar--right', visible);
+  showPanel('as-sidebar--right', visible, 'as-sidebar--visible');
 }
 
 function showLegendsPanel(visible) {

--- a/packages/components/src/components/as-application-content/as-application-content.spec.ts
+++ b/packages/components/src/components/as-application-content/as-application-content.spec.ts
@@ -72,7 +72,7 @@ describe('as-application-content', () => {
 
       expect(mapTab).toMatchClasses(['as-tabs__item']);
       expect(leftSidebarTab).toMatchClasses(['as-tabs__item', 'as-tabs__item--active']);
-      expect(leftSidebarNode).toMatchClasses(['as-sidebar', 'as-sidebar--left', 'as-sidebar--left--visible']);
+      expect(leftSidebarNode).toMatchClasses(['as-sidebar', 'as-sidebar--left', 'as-sidebar--visible']);
     });
   });
 

--- a/packages/components/src/components/as-application-content/as-application-content.tsx
+++ b/packages/components/src/components/as-application-content/as-application-content.tsx
@@ -157,10 +157,8 @@ export class ApplicationContent {
     const sidebars = Array.from(this.element.querySelectorAll('.as-sidebar'));
 
     const sidebarSections = sidebars.map((sidebar, index) => {
-      const sidebarPosition = sidebar.classList.contains('as-sidebar--left') ? 'left' : 'right';
-
       return {
-        activeClass: `as-sidebar--${sidebarPosition}--visible`,
+        activeClass: `as-sidebar--visible`,
         element: sidebar,
         name: sidebar.getAttribute('data-name') || `Sidebar ${index}`,
         tabOrder: sidebar.getAttribute('data-tab-order') || 0,

--- a/packages/components/src/components/as-toolbar/as-toolbar.tsx
+++ b/packages/components/src/components/as-toolbar/as-toolbar.tsx
@@ -33,8 +33,8 @@ export class Toolbar {
   }
 
   private _showTab0(event) {
-    document.querySelector('.as-sidebar.as-sidebar--left').classList.add('as-sidebar--left--visible');
-    document.querySelector('.as-sidebar.as-sidebar--right').classList.remove('as-sidebar--right--visible');
+    document.querySelector('.as-sidebar.as-sidebar--left').classList.add('as-sidebar--visible');
+    document.querySelector('.as-sidebar.as-sidebar--right').classList.remove('as-sidebar--visible');
     document.querySelector('.as-bottom-bar').classList.remove('as-bottom-bar--visible');
     document.querySelector('.as-toolbar-tabs .as-toolbar-tabs__item--active')
       .classList.remove('as-toolbar-tabs__item--active');
@@ -42,8 +42,8 @@ export class Toolbar {
   }
 
   private _showTab1(event) {
-    document.querySelector('.as-sidebar.as-sidebar--left').classList.remove('as-sidebar--left--visible');
-    document.querySelector('.as-sidebar.as-sidebar--right').classList.remove('as-sidebar--right--visible');
+    document.querySelector('.as-sidebar.as-sidebar--left').classList.remove('as-sidebar--visible');
+    document.querySelector('.as-sidebar.as-sidebar--right').classList.remove('as-sidebar--visible');
     document.querySelector('.as-bottom-bar').classList.remove('as-bottom-bar--visible');
     document.querySelector('.as-toolbar-tabs .as-toolbar-tabs__item--active')
       .classList.remove('as-toolbar-tabs__item--active');
@@ -51,8 +51,8 @@ export class Toolbar {
   }
 
   private _showTab2(event) {
-    document.querySelector('.as-sidebar.as-sidebar--right').classList.add('as-sidebar--right--visible');
-    document.querySelector('.as-sidebar.as-sidebar--left').classList.remove('as-sidebar--left--visible');
+    document.querySelector('.as-sidebar.as-sidebar--right').classList.add('as-sidebar--visible');
+    document.querySelector('.as-sidebar.as-sidebar--left').classList.remove('as-sidebar--visible');
     document.querySelector('.as-bottom-bar').classList.remove('as-bottom-bar--visible');
     document.querySelector('.as-toolbar-tabs .as-toolbar-tabs__item--active'
     ).classList.remove('as-toolbar-tabs__item--active');
@@ -60,8 +60,8 @@ export class Toolbar {
   }
 
   private _showTab3(event) {
-    document.querySelector('.as-sidebar.as-sidebar--right').classList.remove('as-sidebar--right--visible');
-    document.querySelector('.as-sidebar.as-sidebar--left').classList.remove('as-sidebar--left--visible');
+    document.querySelector('.as-sidebar.as-sidebar--right').classList.remove('as-sidebar--visible');
+    document.querySelector('.as-sidebar.as-sidebar--left').classList.remove('as-sidebar--visible');
     document.querySelector('.as-bottom-bar').classList.add('as-bottom-bar--visible');
     document.querySelector('.as-toolbar-tabs .as-toolbar-tabs__item--active')
       .classList.remove('as-toolbar-tabs__item--active');

--- a/packages/styles/src/core/containers/test/containers-in-sidebar-bottom-and-legends.html
+++ b/packages/styles/src/core/containers/test/containers-in-sidebar-bottom-and-legends.html
@@ -100,7 +100,7 @@
         </div>
       </div>
     </div>
-    <aside class="as-sidebar as-sidebar--right as-sidebar--right--visible">
+    <aside class="as-sidebar as-sidebar--right as-sidebar--visible">
       <div class="as-container as-container--border">
         <section class="as-box">
           <h1 class="as-title">Right Sidebar</h1>

--- a/packages/styles/src/core/containers/test/containers-in-sidebar.html
+++ b/packages/styles/src/core/containers/test/containers-in-sidebar.html
@@ -20,7 +20,7 @@
 <body class="as-app">
   <main class="as-app-content">
     <div class="as-map-wrapper"></div>
-    <aside class="as-sidebar as-sidebar--right as-sidebar--right--visible">
+    <aside class="as-sidebar as-sidebar--right as-sidebar--visible">
       <div class="as-container as-container--border">
         <section class="as-box">
           <h1 class="as-title">Right Sidebar</h1>

--- a/packages/styles/src/core/layout/sidebar/README.md
+++ b/packages/styles/src/core/layout/sidebar/README.md
@@ -13,7 +13,7 @@ Sidebar position and size can be changed with the following class modifiers.
 
 
 
-Sidebars are hidden by default in mobile devices and only will be shown when the modifier class `as-sidebar--left--visible` or `as-sidebar--right--visible`  is present.
+Sidebars are hidden by default in mobile devices and only will be shown when the modifier class `as-sidebar--visible` is present.
 
 ```html
 noSource: true

--- a/packages/styles/src/core/layout/sidebar/_sidebar.scss
+++ b/packages/styles/src/core/layout/sidebar/_sidebar.scss
@@ -15,9 +15,10 @@
 
   &--left {
     left: -100%;
+    order: -1;
     box-shadow: rgba($color-type-01, 0.16) 1px 0 4px 0;
 
-    &--visible {
+    &.as-sidebar--visible {
       left: 0;
       opacity: 1;
     }
@@ -25,9 +26,10 @@
 
   &--right {
     right: -100%;
+    order: 9999;
     box-shadow: rgba($color-type-01, 0.16) 0 1px 4px 0;
 
-    &--visible {
+    &.as-sidebar--visible {
       right: 0;
       opacity: 1;
     }

--- a/packages/styles/src/core/layout/sidebar/test/sidebar-mobile-visible.html
+++ b/packages/styles/src/core/layout/sidebar/test/sidebar-mobile-visible.html
@@ -19,7 +19,7 @@
 
 <body class="as-app">
   <main class="as-app-content">
-    <aside class="as-sidebar as-sidebar--left as-sidebar--left--visible">
+    <aside class="as-sidebar as-sidebar--left as-sidebar--visible">
       LEFT SIDEBAR
     </aside>
   </main>


### PR DESCRIPTION
We were not respecting sidebar classes to position elements, so this PR fixes that bug. And I made some modifications to sidebar visible classes because they were not BEM compliant.

https://github.com/CartoDB/airship/issues/202