### PR TITLE
Remove thumb text translation

### DIFF
--- a/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.scss
+++ b/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.scss
@@ -23,10 +23,6 @@ as-range-slider-thumb {
     }
   }
 
-  .as-range-slider__thumb:hover .as-range-slider__value {
-    transform: translate3d(-53%, 4px, 0);
-  }
-
   .as-range-slider__thumb-handle {
     width: 12px;
     height: 12px;
@@ -78,9 +74,5 @@ as-range-slider-thumb {
     &:hover {
       transform: translate3d(-6px, 0, 0) scale(1.33);
     }
-  }
-
-  .as-range-slider__thumb-handle--moving + .as-range-slider__value--moving {
-    transform: translate3d(-53%, 4px, 0);
   }
 }


### PR DESCRIPTION
@piensaenpixel told us that the text below the thumb should not move, so I removed the translate property.

https://github.com/CartoDB/airship/issues/171