### PR TITLE
Do not take Other category into account in total percentage sum

### DIFF
--- a/packages/components/src/components/as-category-widget/as-category-widget.spec.ts
+++ b/packages/components/src/components/as-category-widget/as-category-widget.spec.ts
@@ -166,13 +166,12 @@ describe('as-category-widget', () => {
     });
   });
 
-  describe('._getVisibleCategoriesMaximumValue', () => {
+  describe('._getCategoriesMaximumValue', () => {
     it('should return maximum value of visible categories', () => {
-      categoryWidget.categories = exampleCategories;
       categoryWidget.useTotalPercentage = false;
       categoryWidget.visibleCategories = 5;
 
-      expect(categoryWidget._getVisibleCategoriesMaximumValue()).toEqual(1000);
+      expect(categoryWidget._getCategoriesMaximumValue(exampleCategories)).toEqual(1000);
     });
   });
 

--- a/packages/components/src/components/as-category-widget/as-category-widget.tsx
+++ b/packages/components/src/components/as-category-widget/as-category-widget.tsx
@@ -161,7 +161,7 @@ export class CategoryWidget {
 
     const maximumValue = this.useTotalPercentage
       ? this._getCategoriesTotalValue(this.categories)
-      : this._getVisibleCategoriesMaximumValue();
+      : this._getCategoriesMaximumValue(categories, Boolean(otherCategory));
 
     if (otherCategory || moreCategoriesThanVisible) {
       otherCategoryTemplate = this._renderOtherCategory(otherCategory, { maximumValue });
@@ -251,8 +251,8 @@ export class CategoryWidget {
     this.categoriesSelected.emit(this.selectedCategories);
   }
 
-  private _getVisibleCategoriesMaximumValue() {
-    return this._getVisibleCategories().reduce(
+  private _getCategoriesMaximumValue(categories: Category[], otherCategoryPresent: boolean = false) {
+    return this._getVisibleCategories(categories, otherCategoryPresent).reduce(
       (maximum, currentCategory: Category) => currentCategory.value > maximum ? currentCategory.value : maximum, 0
     );
   }
@@ -282,16 +282,20 @@ export class CategoryWidget {
 
     if (otherCategory) {
       const categories = this.categories
-        .filter((category: Category) => category.name !== otherCategory.name);
+        .filter((category: Category) => category.name !== otherCategory.name) as Category[];
 
       return { categories, otherCategory };
     }
 
-    return { categories: this.categories };
+    return { categories: this.categories as Category[] };
   }
 
-  private _getVisibleCategories() {
-    return this.categories.slice(0, this.visibleCategories);
+  private _getVisibleCategories(parsedCategories, otherCategoryPresent: boolean) {
+    if (otherCategoryPresent) {
+      return parsedCategories;
+    }
+
+    return parsedCategories.slice(0, this.visibleCategories);
   }
 }
 


### PR DESCRIPTION
I discovered that we were always taking into account Other category value to calculate total percentage sum to render category bars. This PR solves this by excluding that category from sum.