### PR TITLE
Fix Netlify documentation

### DIFF
--- a/catalog/index.html
+++ b/catalog/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+  <base href="/catalog/">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -60,7 +61,7 @@
         {
           path: '/',
           title: 'Introduction',
-          src: './catalog/intro.md'
+          src: 'intro.md'
         },
         {
           title: 'Layout',

--- a/catalog/index.html
+++ b/catalog/index.html
@@ -234,10 +234,10 @@
               path: '/styles/utilities',
               title: 'Utilities',
               src: '../packages/styles/src/utilities/README.md'
-            }, {
-              path: '/styles/positioning',
-              title: 'Positioning',
-              src: '../packages/styles/src/utilities/positioning/README.md'
+            // }, {
+            //   path: '/styles/positioning',
+            //   title: 'Positioning',
+            //   src: '../packages/styles/src/utilities/positioning/README.md'
             }
           ]
         },

--- a/catalog/index.html
+++ b/catalog/index.html
@@ -60,7 +60,7 @@
         {
           path: '/',
           title: 'Introduction',
-          src: 'intro.md'
+          src: './catalog/intro.md'
         },
         {
           title: 'Layout',

--- a/examples/styles/tabs/tabs-accesible.html
+++ b/examples/styles/tabs/tabs-accesible.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>ARIA compatible Tabs</title>
+  <link rel="stylesheet" href="../../../packages/styles/dist/airship.css">
+
+  <style>
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      background: #F2F2F2;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="as-tabs" role="tablist">
+    <button role="tab" class="as-tabs__item as-tabs__item--active">Maps</button>
+    <button role="tab" class="as-tabs__item">Legends</button>
+    <button role="tab" class="as-tabs__item">Widgets</button>
+  </div>
+</body>
+
+</html>

--- a/examples/styles/tabs/tabs-xl.html
+++ b/examples/styles/tabs/tabs-xl.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Tabs XL</title>
+  <link rel="stylesheet" href="../../../packages/styles/dist/airship.css">
+
+  <style>
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      background: #F2F2F2;
+    }
+  </style>
+</head>
+
+<body>
+  <nav>
+    <ul class="as-tabs as-tabs--xl">
+      <li class="as-tabs__item as-tabs__item--active">
+        <a href="#">Map</a>
+      </li>
+      <li class="as-tabs__item">
+        <a href="#">Legends</a>
+      </li>
+      <li class="as-tabs__item">
+        <a href="#">Widgets</a>
+      </li>
+      <li class="as-tabs__item">
+        <a href="#">Sidebar</a>
+      </li>
+    </ul>
+  </nav>
+</body>
+
+</html>

--- a/examples/styles/tabs/tabs.html
+++ b/examples/styles/tabs/tabs.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Basic Tabs</title>
+  <link rel="stylesheet" href="../../../packages/styles/dist/airship.css">
+
+  <style>
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      background: #F2F2F2;
+    }
+  </style>
+</head>
+
+<body>
+  <nav>
+    <ul class="as-tabs">
+      <li class="as-tabs__item as-tabs__item--active">
+        Map
+      </li>
+      <li class="as-tabs__item">
+        Legends
+      </li>
+      <li class="as-tabs__item">
+        Widgets
+      </li>
+      <li class="as-tabs__item">
+        Sidebar
+      </li>
+    </ul>
+  </nav>
+</body>
+
+</html>

--- a/packages/styles/src/tabs/README.md
+++ b/packages/styles/src/tabs/README.md
@@ -9,7 +9,7 @@ To highlight the current tab you can use `as-tabs__item--active` class modifier.
 
 ```html
 ---
-<iframe src="/packages/styles/src/tabs/test/tabs.html" style="width: 100%; height: 100%;">
+<iframe src="/examples/styles/tabs/tabs.html" style="width: 100%; height: 100%;">
 ```
 
 ```code
@@ -40,7 +40,7 @@ You can use the `as-tabs--xl` class modifier to create a slightly bigger tab ele
 
 ```html
 ---
-<iframe src="/packages/styles/src/tabs/test/tabs-xl.html" style="width: 100%; height: 100%;">
+<iframe src="/examples/styles/tabs/tabs-xl.html" style="width: 100%; height: 100%;">
 ```
 
 ```code
@@ -71,7 +71,7 @@ The tabs element is also ARIA compatible, using the roles `tablist` and `tabs` i
 
 ```html
 ---
-<iframe src="/packages/styles/src/tabs/test/tabs-accesible.html" style="width: 100%; height: 100%;">
+<iframe src="/examples/styles/tabs/tabs-accesible.html" style="width: 100%; height: 100%;">
 ```
 
 ```code


### PR DESCRIPTION
Netlify docs are now broken because some changes due to DC integration. `intro` page is not working.

Apart from that, tab code has been copied from their `test` folder to `examples` for Catalog to be able to access it in DC.