### PR TITLE
Adjust selection to bucket start when data changes

### DIFF
--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -327,9 +327,9 @@ export class HistogramWidget {
 
     for (const iterator of this.data) {
       const breakPoint = iterator.start + Math.floor((iterator.end - iterator.start) / 2);
-      if (value >= iterator.start && value < breakPoint) {
+      if (value >= iterator.start && value <= breakPoint) {
         return iterator.start;
-      } else if (value >= breakPoint && value < iterator.end) {
+      } else if (value > breakPoint && value < iterator.end) {
         return iterator.end;
       }
     }


### PR DESCRIPTION
This issue fixes #289.

The jumpy behaviour was caused because we were setting the range start to the next bucket instead of the same one that was previously selected when new data was set.