### PR TITLE
Fix Range Slider bugs

### DIFF
--- a/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
+++ b/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
@@ -1,4 +1,5 @@
 import { Component, Event, EventEmitter, Prop, State, Watch } from '@stencil/core';
+import getDecimalPlaces from '../../../utils/get-decimal-places';
 import { Thumb } from '../thumb/as-range-slider-thumb';
 
 @Component({
@@ -309,20 +310,4 @@ export class RangeSlider {
   private roundToStep(numberToRound: number, step: number) {
     return Number.parseFloat(numberToRound.toFixed(getDecimalPlaces(step)));
   }
-}
-
-function getDecimalPlaces(decimalNumber): number {
-  // Copied this method from: https://bit.ly/2DfxbfQ
-
-  function hasFraction(numberToCheck) {
-    return Math.abs(Math.round(numberToCheck) - numberToCheck) > 1e-10;
-  }
-
-  let count = 0;
-  // multiply by increasing powers of 10 until the fractional part is ~ 0
-  while (hasFraction(decimalNumber * (10 ** count)) && isFinite(10 ** count)) {
-    count++;
-  }
-
-  return count;
 }

--- a/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
+++ b/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
@@ -302,6 +302,27 @@ export class RangeSlider {
   }
 
   private _getStepValue(value) {
-    return Math.round(value / this.step) * this.step;
+    const stepValue = (value / this.step) * this.step;
+    return this.roundToStep(stepValue, this.step);
   }
+
+  private roundToStep(numberToRound: number, step: number) {
+    return Number.parseFloat(numberToRound.toFixed(getDecimalPlaces(step)));
+  }
+}
+
+function getDecimalPlaces(decimalNumber): number {
+  // Copied this method from: https://bit.ly/2DfxbfQ
+
+  function hasFraction(numberToCheck) {
+    return Math.abs(Math.round(numberToCheck) - numberToCheck) > 1e-10;
+  }
+
+  let count = 0;
+  // multiply by increasing powers of 10 until the fractional part is ~ 0
+  while (hasFraction(decimalNumber * (10 ** count)) && isFinite(10 ** count)) {
+    count++;
+  }
+
+  return count;
 }

--- a/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
+++ b/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
@@ -137,8 +137,7 @@ export class RangeSliderThumb extends MouseTrack {
   }
 
   private _getDisplayValue(value: number) {
-    const displayValue = Math.round(value);
-    return (this.formatValue && this.formatValue(displayValue)) || displayValue;
+    return (this.formatValue && this.formatValue(value)) || value;
   }
 
   private setCursorTo(value) {

--- a/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
+++ b/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
@@ -24,6 +24,7 @@ export class RangeSliderThumb extends MouseTrack {
   @Element() public element: HTMLElement;
   public railElement: HTMLElement;
   public thumbValue: HTMLElement;
+  public railBoundingClientRect: ClientRect | DOMRect;
 
   public render() {
     const thumbStyles = {
@@ -68,6 +69,8 @@ export class RangeSliderThumb extends MouseTrack {
 
     this.thumbValue = thumb.parentElement.querySelector('.as-range-slider__value');
     this.thumbValue.classList.add('as-range-slider__value--moving');
+
+    this.railBoundingClientRect = this.railElement.getBoundingClientRect();
 
     super.handleMouseDown({
       move: (moveEvent) => this._onMove(moveEvent),
@@ -115,7 +118,7 @@ export class RangeSliderThumb extends MouseTrack {
   private _onMove(event: MouseEvent) {
     this.setCursorTo('grabbing');
 
-    const barPercentage = (event.pageX - this.railElement.offsetLeft) * 100 / this.railElement.offsetWidth;
+    const barPercentage = (event.pageX - this.railBoundingClientRect.left) * 100 / this.railElement.offsetWidth;
 
     if (barPercentage < 0 || barPercentage > 100) {
       return;

--- a/packages/components/src/utils/get-decimal-places.ts
+++ b/packages/components/src/utils/get-decimal-places.ts
@@ -1,0 +1,15 @@
+export default function getDecimalPlaces(decimalNumber): number {
+  // Copied this method from: https://bit.ly/2DfxbfQ
+
+  function hasFraction(numberToCheck) {
+    return Math.abs(Math.round(numberToCheck) - numberToCheck) > 1e-10;
+  }
+
+  let count = 0;
+  // multiply by increasing powers of 10 until the fractional part is ~ 0
+  while (hasFraction(decimalNumber * (10 ** count)) && isFinite(10 ** count)) {
+    count++;
+  }
+
+  return count;
+}


### PR DESCRIPTION
This PR fix #315 and fix #312.

Range slider thumb position was being calculated with rail's offsetLeft, and it was not calculated properly when any of the parent elements had any `position: relative`, like `.as-main`. So, this PR uses left offset from `.getBoundingClientRect` which is relative to `document` origin.

Apart from that, we didn't allow decimal numbers in slider's step, and now we do! 🎉 