### PR TITLE
Adjust SVG inner elements to bounds

### DIFF
--- a/packages/components/src/components/as-histogram-widget/__snapshots__/as-histogram-widget.spec.ts.snap
+++ b/packages/components/src/components/as-histogram-widget/__snapshots__/as-histogram-widget.spec.ts.snap
@@ -15,16 +15,14 @@ exports[`as-histogram-widget Rendering should not render header when showHeader 
     >
       
     </span>
-    <svg
-      viewBox="0 0 248 160"
-    >
+    <svg>
       <g
         class="yAxis"
         fill="none"
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       />
       <g
         class="xAxis"
@@ -32,7 +30,7 @@ exports[`as-histogram-widget Rendering should not render header when showHeader 
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(35, 140)"
+        transform="translate(30, 130)"
       >
         <g
           class="tick"
@@ -42,14 +40,14 @@ exports[`as-histogram-widget Rendering should not render header when showHeader 
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             0
           </text>
         </g>
       </g>
       <g
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       />
       <g
         class="brush"
@@ -61,9 +59,9 @@ exports[`as-histogram-widget Rendering should not render header when showHeader 
           cursor="crosshair"
           height="125"
           pointer-events="all"
-          width="205"
-          x="35"
-          y="15"
+          width="-20"
+          x="30"
+          y="5"
         />
         <rect
           class="selection"
@@ -110,8 +108,8 @@ exports[`as-histogram-widget Rendering should not render header when showHeader 
           stroke="var(--as-color-complementary, #47DB99)"
           stroke-width="4"
           style="opacity: 0;"
-          y1="140"
-          y2="140"
+          y1="130"
+          y2="130"
         />
       </g>
     </svg>
@@ -144,16 +142,14 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
     >
       
     </span>
-    <svg
-      viewBox="0 0 248 160"
-    >
+    <svg>
       <g
         class="yAxis"
         fill="none"
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       >
         <g
           class="tick"
@@ -162,12 +158,12 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             0
           </text>
@@ -179,12 +175,12 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             5
           </text>
@@ -196,12 +192,12 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             10
           </text>
@@ -213,12 +209,12 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             15
           </text>
@@ -230,12 +226,12 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             20
           </text>
@@ -247,7 +243,7 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(35, 140)"
+        transform="translate(30, 130)"
       >
         <g
           class="tick"
@@ -257,7 +253,7 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             0
           </text>
@@ -265,12 +261,12 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(51.75,0)"
+          transform="translate(-9.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             10
           </text>
@@ -278,12 +274,12 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(103,0)"
+          transform="translate(-19.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             20
           </text>
@@ -291,12 +287,12 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(154.25,0)"
+          transform="translate(-29.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             30
           </text>
@@ -304,25 +300,25 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(205.5,0)"
+          transform="translate(-39.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             40
           </text>
         </g>
       </g>
       <g
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       >
         <rect
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
+          width="0"
           x="0"
           y="125"
         />
@@ -330,24 +326,24 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
-          x="51.25"
+          width="0"
+          x="-10"
           y="125"
         />
         <rect
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
-          x="102.5"
+          width="0"
+          x="-20"
           y="125"
         />
         <rect
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
-          x="153.75"
+          width="0"
+          x="-30"
           y="125"
         />
       </g>
@@ -361,9 +357,9 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
           cursor="crosshair"
           height="125"
           pointer-events="all"
-          width="205"
-          x="35"
-          y="15"
+          width="-20"
+          x="30"
+          y="5"
         />
         <rect
           class="selection"
@@ -410,14 +406,14 @@ exports[`as-histogram-widget Rendering should render clear button 1`] = `
           stroke="var(--as-color-complementary, #47DB99)"
           stroke-width="4"
           style="opacity: 0;"
-          y1="140"
-          y2="140"
+          y1="130"
+          y2="130"
         />
       </g>
     </svg>
   </div>
   <button
-    class="as-btn as-btn--primary as-btn--s as-category-widget__clear"
+    class="as-btn as-btn--primary as-btn--s as-histogram-widget__clear"
   >
     Clear selection
   </button>
@@ -448,16 +444,14 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
     >
       
     </span>
-    <svg
-      viewBox="0 0 248 160"
-    >
+    <svg>
       <g
         class="yAxis"
         fill="none"
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       >
         <g
           class="tick"
@@ -466,12 +460,12 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             0
           </text>
@@ -483,12 +477,12 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             5
           </text>
@@ -500,12 +494,12 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             10
           </text>
@@ -517,12 +511,12 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             15
           </text>
@@ -534,12 +528,12 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             20
           </text>
@@ -551,7 +545,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(35, 140)"
+        transform="translate(30, 130)"
       >
         <g
           class="tick"
@@ -561,7 +555,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             0
           </text>
@@ -569,12 +563,12 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(51.75,0)"
+          transform="translate(-9.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             10
           </text>
@@ -582,12 +576,12 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(103,0)"
+          transform="translate(-19.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             20
           </text>
@@ -595,12 +589,12 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(154.25,0)"
+          transform="translate(-29.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             30
           </text>
@@ -608,25 +602,25 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(205.5,0)"
+          transform="translate(-39.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             40
           </text>
         </g>
       </g>
       <g
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       >
         <rect
           class="bar"
           height="0"
           style="fill: #EEFFFF;"
-          width="50.25"
+          width="0"
           x="0"
           y="125"
         />
@@ -634,24 +628,24 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           class="bar"
           height="0"
           style="fill: #EEFFFF;"
-          width="50.25"
-          x="51.25"
+          width="0"
+          x="-10"
           y="125"
         />
         <rect
           class="bar"
           height="0"
           style="fill: #FFAAAA;"
-          width="50.25"
-          x="102.5"
+          width="0"
+          x="-20"
           y="125"
         />
         <rect
           class="bar"
           height="0"
           style="fill: #FFAAAA;"
-          width="50.25"
-          x="153.75"
+          width="0"
+          x="-30"
           y="125"
         />
       </g>
@@ -665,9 +659,9 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           cursor="crosshair"
           height="125"
           pointer-events="all"
-          width="205"
-          x="35"
-          y="15"
+          width="-20"
+          x="30"
+          y="5"
         />
         <rect
           class="selection"
@@ -678,9 +672,9 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           shape-rendering="crispEdges"
           stroke="#fff"
           style=""
-          width="102.5"
-          x="35"
-          y="15"
+          width="-20"
+          x="30"
+          y="5"
         />
         <rect
           class="handle handle--e"
@@ -688,8 +682,8 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           height="130"
           style=""
           width="5"
-          x="135"
-          y="12.5"
+          x="7.5"
+          y="2.5"
         />
         <rect
           class="handle handle--w"
@@ -697,8 +691,8 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           height="130"
           style=""
           width="5"
-          x="32.5"
-          y="12.5"
+          x="27.5"
+          y="2.5"
         />
         <rect
           class="handle--custom"
@@ -708,7 +702,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           rx="100"
           ry="100"
           style="opacity: 1;"
-          transform="translate(27.5,132.5)"
+          transform="translate(22.5,122.5)"
           width="15"
         />
         <rect
@@ -719,7 +713,7 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           rx="100"
           ry="100"
           style="opacity: 1;"
-          transform="translate(130,132.5)"
+          transform="translate(2.5,122.5)"
           width="15"
         />
         <line
@@ -728,10 +722,10 @@ exports[`as-histogram-widget Rendering should render colors properly 1`] = `
           stroke="var(--as-color-complementary, #47DB99)"
           stroke-width="4"
           style="opacity: 1;"
-          x1="35"
-          x2="137.5"
-          y1="140"
-          y2="140"
+          x1="30"
+          x2="10"
+          y1="130"
+          y2="130"
         />
       </g>
     </svg>
@@ -764,16 +758,14 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
     >
       
     </span>
-    <svg
-      viewBox="0 0 248 160"
-    >
+    <svg>
       <g
         class="yAxis"
         fill="none"
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       >
         <g
           class="tick"
@@ -782,12 +774,12 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             0
           </text>
@@ -799,12 +791,12 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             5
           </text>
@@ -816,12 +808,12 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             10
           </text>
@@ -833,12 +825,12 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             15
           </text>
@@ -850,12 +842,12 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             20
           </text>
@@ -867,7 +859,7 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(35, 140)"
+        transform="translate(30, 130)"
       >
         <g
           class="tick"
@@ -877,7 +869,7 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             0
           </text>
@@ -885,12 +877,12 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(51.75,0)"
+          transform="translate(-9.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             10
           </text>
@@ -898,12 +890,12 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(103,0)"
+          transform="translate(-19.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             20
           </text>
@@ -911,12 +903,12 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(154.25,0)"
+          transform="translate(-29.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             30
           </text>
@@ -924,25 +916,25 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(205.5,0)"
+          transform="translate(-39.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             40
           </text>
         </g>
       </g>
       <g
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       >
         <rect
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
+          width="0"
           x="0"
           y="125"
         />
@@ -950,24 +942,24 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
-          x="51.25"
+          width="0"
+          x="-10"
           y="125"
         />
         <rect
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
-          x="102.5"
+          width="0"
+          x="-20"
           y="125"
         />
         <rect
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
-          x="153.75"
+          width="0"
+          x="-30"
           y="125"
         />
       </g>
@@ -981,9 +973,9 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
           cursor="crosshair"
           height="125"
           pointer-events="all"
-          width="205"
-          x="35"
-          y="15"
+          width="-20"
+          x="30"
+          y="5"
         />
         <rect
           class="selection"
@@ -1030,14 +1022,14 @@ exports[`as-histogram-widget Rendering should render properly 1`] = `
           stroke="var(--as-color-complementary, #47DB99)"
           stroke-width="4"
           style="opacity: 0;"
-          y1="140"
-          y2="140"
+          y1="130"
+          y2="130"
         />
       </g>
     </svg>
   </div>
   <button
-    class="as-btn as-btn--primary as-btn--s as-category-widget__clear"
+    class="as-btn as-btn--primary as-btn--s as-histogram-widget__clear"
   >
     Clear selection
   </button>
@@ -1068,16 +1060,14 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
     >
       
     </span>
-    <svg
-      viewBox="0 0 248 160"
-    >
+    <svg>
       <g
         class="yAxis"
         fill="none"
         font-family="sans-serif"
         font-size="10"
         text-anchor="end"
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       >
         <g
           class="tick"
@@ -1086,12 +1076,12 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             0
           </text>
@@ -1103,12 +1093,12 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             5
           </text>
@@ -1120,12 +1110,12 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             10
           </text>
@@ -1137,12 +1127,12 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             15
           </text>
@@ -1154,12 +1144,12 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         >
           <line
             stroke="currentColor"
-            x2="205"
+            x2="-40"
           />
           <text
             dy="0.32em"
             fill="currentColor"
-            x="-10"
+            x="-50"
           >
             20
           </text>
@@ -1171,7 +1161,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         font-family="sans-serif"
         font-size="10"
         text-anchor="middle"
-        transform="translate(35, 140)"
+        transform="translate(30, 130)"
       >
         <g
           class="tick"
@@ -1181,7 +1171,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             0
           </text>
@@ -1189,12 +1179,12 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(51.75,0)"
+          transform="translate(-9.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             10
           </text>
@@ -1202,12 +1192,12 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(103,0)"
+          transform="translate(-19.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             20
           </text>
@@ -1215,12 +1205,12 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(154.25,0)"
+          transform="translate(-29.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             30
           </text>
@@ -1228,25 +1218,25 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
         <g
           class="tick"
           opacity="1"
-          transform="translate(205.5,0)"
+          transform="translate(-39.5,0)"
         >
           <text
             dy="0.71em"
             fill="currentColor"
-            y="10"
+            y="50"
           >
             40
           </text>
         </g>
       </g>
       <g
-        transform="translate(35, 15)"
+        transform="translate(30, 5)"
       >
         <rect
           class="bar"
           height="0"
           style="fill: var(--as-color-complementary, #47DB99);"
-          width="50.25"
+          width="0"
           x="0"
           y="125"
         />
@@ -1254,24 +1244,24 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           class="bar"
           height="0"
           style="fill: var(--as-color-complementary, #47DB99);"
-          width="50.25"
-          x="51.25"
+          width="0"
+          x="-10"
           y="125"
         />
         <rect
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
-          x="102.5"
+          width="0"
+          x="-20"
           y="125"
         />
         <rect
           class="bar"
           height="0"
           style="fill: var(--as-color-primary, #1785FB);"
-          width="50.25"
-          x="153.75"
+          width="0"
+          x="-30"
           y="125"
         />
       </g>
@@ -1285,9 +1275,9 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           cursor="crosshair"
           height="125"
           pointer-events="all"
-          width="205"
-          x="35"
-          y="15"
+          width="-20"
+          x="30"
+          y="5"
         />
         <rect
           class="selection"
@@ -1298,9 +1288,9 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           shape-rendering="crispEdges"
           stroke="#fff"
           style=""
-          width="102.5"
-          x="35"
-          y="15"
+          width="-20"
+          x="30"
+          y="5"
         />
         <rect
           class="handle handle--e"
@@ -1308,8 +1298,8 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           height="130"
           style=""
           width="5"
-          x="135"
-          y="12.5"
+          x="7.5"
+          y="2.5"
         />
         <rect
           class="handle handle--w"
@@ -1317,8 +1307,8 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           height="130"
           style=""
           width="5"
-          x="32.5"
-          y="12.5"
+          x="27.5"
+          y="2.5"
         />
         <rect
           class="handle--custom"
@@ -1328,7 +1318,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           rx="100"
           ry="100"
           style="opacity: 1;"
-          transform="translate(27.5,132.5)"
+          transform="translate(22.5,122.5)"
           width="15"
         />
         <rect
@@ -1339,7 +1329,7 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           rx="100"
           ry="100"
           style="opacity: 1;"
-          transform="translate(130,132.5)"
+          transform="translate(2.5,122.5)"
           width="15"
         />
         <line
@@ -1348,10 +1338,10 @@ exports[`as-histogram-widget Rendering should render selection properly 1`] = `
           stroke="var(--as-color-complementary, #47DB99)"
           stroke-width="4"
           style="opacity: 1;"
-          x1="35"
-          x2="137.5"
-          y1="140"
-          y2="140"
+          x1="30"
+          x2="10"
+          y1="130"
+          y2="130"
         />
       </g>
     </svg>

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -3,6 +3,7 @@
 
 as-histogram-widget {
   display: block;
+  width: 100%;
   background: var(--histogram-widget--background-color, $color-ui-01);
 
   .as-histogram-widget__header {
@@ -11,11 +12,16 @@ as-histogram-widget {
   }
 
   .as-histogram-widget__description {
+    margin-bottom: get-spacing(4);
     color: var(--description--color, $color-type-02);
   }
 
   .as-histogram-widget__wrapper {
     position: relative;
+  }
+
+  .as-histogram-widget__clear {
+    margin-top: get-spacing(2);
   }
 
   .as-histogram-widget__tooltip {
@@ -30,6 +36,7 @@ as-histogram-widget {
 
   svg {
     display: block;
+    width: 100%;
     overflow: visible;
 
     .brush {
@@ -59,7 +66,7 @@ as-histogram-widget {
     }
 
     text {
-      fill: $color-ui-04;
+      fill: $color-type-01;
     }
   }
 

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -17,14 +17,14 @@ import { shadeOrBlend } from '../../utils/styles';
 const CUSTOM_HANDLE_SIZE = 15;
 const DEFAULT_BAR_COLOR = 'var(--as-color-primary, #1785FB)';
 const DEFAULT_SELECTED_BAR_COLOR = 'var(--as-color-complementary, #47DB99)';
-const WIDTH = 205;
 const HEIGHT = 125;
 const BARS_SEPARATION = 1;
 const MARGIN = {
   BOTTOM: 15,
-  LEFT: 35,
+  LEFT: 30,
   RIGHT: 3,
-  TOP: 15,
+  TOP: 5,
+  YAxis: 20
 };
 const CUSTOM_HANDLE_Y_COORD = HEIGHT + MARGIN.TOP - (CUSTOM_HANDLE_SIZE / 2);
 
@@ -151,6 +151,8 @@ export class HistogramWidget {
   private bottomLine: Selection<BaseType, {}, BaseType, {}>;
   private selection: number[] = null;
 
+  private chartWidth: number;
+
   /**
    * Default formatting function. Makes the value a readable number and
    * converts it into a string. Useful to compose with your own formatting
@@ -227,6 +229,8 @@ export class HistogramWidget {
   }
 
   public render() {
+    this.chartWidth = this.el.offsetWidth - MARGIN.YAxis;
+
     const histogramClasses = {
       'as-histogram-widget__wrapper': true,
       'as-histogram-widget__wrapper--disabled': this.disableInteractivity
@@ -236,7 +240,7 @@ export class HistogramWidget {
       this._renderHeader(),
       <div class={histogramClasses}>
         {this._renderTooltip()}
-        <svg ref={(ref: HTMLElement) => this.container = select(ref)} viewBox='0 0 248 160'></svg>
+        <svg ref={(ref: HTMLElement) => this.container = select(ref)}></svg>
       </div>,
       this.showClear && !this.disableInteractivity ? this._renderClearBtn() : '',
     ];
@@ -252,7 +256,7 @@ export class HistogramWidget {
 
     this.brush = brushX()
       .handleSize(BARS_SEPARATION + 4)
-      .extent([[MARGIN.LEFT, MARGIN.TOP], [WIDTH + MARGIN.LEFT, HEIGHT + MARGIN.TOP]])
+      .extent([[MARGIN.LEFT, MARGIN.TOP], [this.chartWidth + MARGIN.LEFT, HEIGHT + MARGIN.TOP]])
       .on('brush', this._onBrush.bind(this))
       .on('end', this._onBrushEnd.bind(this));
 
@@ -454,6 +458,7 @@ export class HistogramWidget {
 
   private _renderYAxis() {
     const data = this.data;
+    const barsWidth = this.chartWidth - MARGIN.YAxis;
 
     // -- Y Axis
     this.yScale = scaleLinear()
@@ -462,7 +467,7 @@ export class HistogramWidget {
       .nice();
 
     this.yAxis = axisLeft(this.yScale)
-      .tickSize(-WIDTH)
+      .tickSize(-barsWidth)
       .ticks(5)
       .tickPadding(10)
       .tickFormat(format('.2~s'));
@@ -476,30 +481,31 @@ export class HistogramWidget {
 
   private _renderXAxis() {
     const data = this.data;
+    const barsWidth = this.chartWidth - MARGIN.YAxis;
 
     const { start } = data.length > 0 ? data[0] : { start: 0 };
     const { end } = data.length > 0 ? data[data.length - 1] : { end: 0 };
 
     this.xScale = scaleLinear()
       .domain([start, end])
-      .range([0, WIDTH]);
+      .range([0, barsWidth]);
 
     this.xAxis = axisBottom(this.xScale)
-      .tickSize(-WIDTH)
+      .tickSize(-barsWidth)
       .ticks(3)
       .tickPadding(10);
 
     this.xAxisSelection = this.container
       .append('g')
       .attr('class', 'xAxis')
-      .attr('transform', `translate(${MARGIN.LEFT}, ${HEIGHT + MARGIN.BOTTOM})`)
+      .attr('transform', `translate(${MARGIN.LEFT}, ${HEIGHT + MARGIN.TOP})`)
       .call(this.xAxis);
   }
 
   private _renderBars() {
     const data = this.data;
-    const barWidth = data.length === 0 ? WIDTH : WIDTH / data.length;
-
+    const barsWidth = this.chartWidth - MARGIN.YAxis;
+    const barWidth = data.length === 0 ? barsWidth : barsWidth / data.length;
     // -- Draw bars
     this.bars = this.barsContainer
       .selectAll('rect')
@@ -628,7 +634,7 @@ export class HistogramWidget {
   private _renderClearBtn() {
     return (
       <button
-        class='as-btn as-btn--primary as-btn--s as-category-widget__clear'
+        class='as-btn as-btn--primary as-btn--s as-histogram-widget__clear'
         onClick={() => this._setSelection(null) }>Clear selection
       </button>
     );


### PR DESCRIPTION
Fix #320.

I fixed SVG height issues, but we need to add a note to documentation telling that if you use that widget in a panel you should put a fixed width by default. Otherwise it would render wrongly because its initial width will be 0.