### PR TITLE
Remove listeners for Touch events in Range Slider

### DIFF
--- a/packages/components/src/components/as-range-slider/MouseTrack.ts
+++ b/packages/components/src/components/as-range-slider/MouseTrack.ts
@@ -22,7 +22,11 @@ export class MouseTrack {
 
   private _handleRelease(eventProperties: MouseEvent, listeners: MouseListeners, customListeners: MouseListeners) {
     document.removeEventListener('mousemove', listeners.move);
+    document.removeEventListener('touchmove', listeners.move);
     document.removeEventListener('mouseup', listeners.release);
+    document.removeEventListener('touchend', listeners.release);
+
+    document.removeEventListener('dragstart', this.preventAndStop);
 
     if (customListeners.move) {
       customListeners.move(eventProperties);

--- a/packages/components/src/components/as-range-slider/track/as-range-slider-bar.spec.ts
+++ b/packages/components/src/components/as-range-slider/track/as-range-slider-bar.spec.ts
@@ -47,8 +47,8 @@ describe('as-range-slider-bar', () => {
         element.rangeBarElement = { offsetLeft: 20 } as HTMLElement;
         element.barMove = { emit: barMoveEmitSpy };
 
-        const firstEvent = { clientX: 20 } as MouseEvent;
-        const secondEvent = { clientX: 0 } as MouseEvent;
+        const firstEvent = { pageX: 20 } as MouseEvent;
+        const secondEvent = { pageX: 0 } as MouseEvent;
 
         // Set the mouse position to the current bar position
         element.onMove(firstEvent);
@@ -71,8 +71,8 @@ describe('as-range-slider-bar', () => {
         element.rangeBarElement = { offsetLeft: 20 } as HTMLElement;
         element.barMove = { emit: barMoveEmitSpy };
 
-        const firstEvent = { clientX: 20 } as MouseEvent;
-        const secondEvent = { clientX: 1000 } as MouseEvent;
+        const firstEvent = { pageX: 20 } as MouseEvent;
+        const secondEvent = { pageX: 1000 } as MouseEvent;
 
         // Set the mouse position to the current bar position
         element.onMove(firstEvent);
@@ -94,8 +94,8 @@ describe('as-range-slider-bar', () => {
         element.rangeBarElement = { offsetLeft: 20 } as HTMLElement;
         element.barMove = { emit: barMoveEmitSpy };
 
-        const firstEvent = { clientX: 20 } as MouseEvent;
-        const secondEvent = { clientX: -1000 } as MouseEvent;
+        const firstEvent = { pageX: 20 } as MouseEvent;
+        const secondEvent = { pageX: -1000 } as MouseEvent;
 
         // Set the mouse position to the current bar position
         element.onMove(firstEvent);

--- a/packages/components/src/components/as-range-slider/track/as-range-slider-bar.tsx
+++ b/packages/components/src/components/as-range-slider/track/as-range-slider-bar.tsx
@@ -134,7 +134,7 @@ export class RangeSliderBar extends MouseTrack {
     this.barChangeEnd.emit();
   }
 
-  private _getMovementDelta(currentEvent: MouseEvent, previousEvent: MouseEvent) {
+  private _getMovementDelta(currentEvent: MouseEvent | TouchEvent, previousEvent: MouseEvent | TouchEvent) {
     const currentEventX = currentEvent instanceof TouchEvent
       ? currentEvent.changedTouches[0].pageX
       : currentEvent.pageX;

--- a/packages/components/src/components/as-range-slider/track/as-range-slider-bar.tsx
+++ b/packages/components/src/components/as-range-slider/track/as-range-slider-bar.tsx
@@ -135,7 +135,15 @@ export class RangeSliderBar extends MouseTrack {
   }
 
   private _getMovementDelta(currentEvent: MouseEvent, previousEvent: MouseEvent) {
-    return currentEvent.clientX - previousEvent.clientX;
+    const currentEventX = currentEvent instanceof TouchEvent
+      ? currentEvent.changedTouches[0].pageX
+      : currentEvent.pageX;
+
+    const previousEventX = previousEvent instanceof TouchEvent
+    ? previousEvent.changedTouches[0].pageX
+    : previousEvent.pageX;
+
+    return currentEventX - previousEventX;
   }
 
   private _getRangeDifference() {


### PR DESCRIPTION
Fix #346.

The `touchstart` and `touchend` event listeners were not being properly removed, hence we were moving all thumbs 🤦‍♂️ .

I updated slider event to make it work in mobile. We were not getting touch event position properly.