### PR TITLE
Escape double dashes in Markdown

### DIFF
--- a/packages/components/src/components/as-category-widget/README.md
+++ b/packages/components/src/components/as-category-widget/README.md
@@ -184,7 +184,7 @@ categoryWidget.visibleCategories = 5;
 ### Styles
 There are some CSS Variables that you can override to change visual styles.
 
-#### **--category-widget--description--color**
+#### **\--category-widget\--description\--color**
 Default: $color-type-02 (`#1785FB`)
 
 ```code
@@ -193,7 +193,7 @@ lang: javascript
 document.body.style.setProperty('--category-widget--description--color', '#1785FB')
 ```
 
-#### **--category-widget--bar--height**
+#### **\--category-widget\--bar\--height**
 Default: `4px`
 
 ```code
@@ -202,7 +202,7 @@ lang: javascript
 document.body.style.setProperty('--category-widget--bar--height', '8px')
 ```
 
-#### **--category-widget--background-color**
+#### **\--category-widget\--background-color**
 Default: $color-ui-10 (`#FFF`)
 
 ```code
@@ -211,7 +211,7 @@ lang: javascript
 document.body.style.setProperty('--category-widget--background-color', '#F5F5F5')
 ```
 
-#### **--category-bar--background-color**
+#### **\--category-bar\--background-color**
 Default: $color-ui-20 (`#F5F5F5`)
 
 ```code

--- a/packages/components/src/components/as-category-widget/as-category-widget.scss
+++ b/packages/components/src/components/as-category-widget/as-category-widget.scss
@@ -19,7 +19,7 @@ as-category-widget {
 
   .as-category-widget__description,
   .as-category-widget__count {
-    color: var(--description--color, $color-type-02);
+    color: var(--category-widget--description--color, $color-type-02);
     color: $color-type-02;
   }
 

--- a/packages/components/src/components/as-dropdown/README.md
+++ b/packages/components/src/components/as-dropdown/README.md
@@ -108,7 +108,7 @@ dropdown.canClear = true;
 ### Styles
 There are some CSS Variables that you can override to change visual styles.
 
-#### **--dropdown-main-color**
+#### **\--dropdown-main-color**
 Default: $color-primary (`#1785FB`)
 
 ```code

--- a/packages/components/src/components/as-histogram-widget/README.md
+++ b/packages/components/src/components/as-histogram-widget/README.md
@@ -163,40 +163,22 @@ histogramWidget.tooltipFormatter = function (data) {
 ### Styles
 There are some CSS Variables that you can override to change visual styles.
 
-#### **--category-widget--description--color**
+#### **\--histogram-widget\--description-color**
 Default: $color-type-02 (`#1785FB`)
 
 ```code
 lang: javascript
 ---
-document.body.style.setProperty('--category-widget--description--color', '#1785FB')
+document.body.style.setProperty('--histogram-widget--description-color', '#1785FB')
 ```
 
-#### **--category-widget--bar--height**
-Default: `4px`
+#### **\--histogram-widget\--background-color**
+Default: $color-ui-01 (`#FFF`)
 
 ```code
 lang: javascript
 ---
-document.body.style.setProperty('--category-widget--bar--height', '8px')
-```
-
-#### **--category-widget--background-color**
-Default: $color-ui-10 (`#FFF`)
-
-```code
-lang: javascript
----
-document.body.style.setProperty('--category-widget--background-color', '#F5F5F5')
-```
-
-#### **--category-bar--background-color**
-Default: $color-ui-20 (`#F5F5F5`)
-
-```code
-lang: javascript
----
-document.body.style.setProperty('--category-bar--background-color', '#E2E6E3')
+document.body.style.setProperty('--histogram-widget--background-color', '#F5F5F5')
 ```
 
 ### Events

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -13,7 +13,7 @@ as-histogram-widget {
 
   .as-histogram-widget__description {
     margin-bottom: get-spacing(4);
-    color: var(--description--color, $color-type-02);
+    color: var(--histogram-widget--description-color, $color-type-02);
   }
 
   .as-histogram-widget__wrapper {

--- a/packages/styles/src/core/layout/main/map-footer/README.md
+++ b/packages/styles/src/core/layout/main/map-footer/README.md
@@ -188,7 +188,7 @@ showSource: true
 </div>
 ```
 
-### .as-container--border
+### .as-container\--border
 
 ```html
 showSource: true

--- a/packages/styles/src/core/layout/sidebar/README.md
+++ b/packages/styles/src/core/layout/sidebar/README.md
@@ -9,7 +9,7 @@ Sidebars are hidden by default in mobile devices and only will be shown when the
 
 Sidebar position and size can be changed with the following class modifiers.
 
-### .as-sidebar--left
+### .as-sidebar\--left
 
 Puts the sidebar on the left of the map.
 
@@ -28,7 +28,7 @@ showSource: true
 </div>
 ```
 
-### .as-sidebar--right
+### .as-sidebar\--right
 
 Puts the sidebar on the right of the map.
 
@@ -47,7 +47,7 @@ showSource: true
 
 
 
-### .as-sidebar--l
+### .as-sidebar\--l
 
 Makes the sidebar to be 360px width.
 
@@ -64,7 +64,7 @@ showSource: true
 </div>
 ```
 
-### .as-sidebar--xl
+### .as-sidebar\--xl
 
 Makes the sidebar to be 460px width.
 
@@ -82,7 +82,7 @@ showSource: true
 ```
 
 
-### .as-sidebar--visible
+### .as-sidebar\--visible
 
 Makes the sidebar visible on small screens, filling all the space available in the `.app-content` and covering the map.
 

--- a/packages/styles/src/core/layout/toolbar/README.md
+++ b/packages/styles/src/core/layout/toolbar/README.md
@@ -8,11 +8,11 @@ showSource: true
 
 
 ## Toolbar positioning
-Toolbar is positioned to the top of the page by default. You can specify a different toolbar position using **class modifiers** in the `as-app` element. 
+Toolbar is positioned to the top of the page by default. You can specify a different toolbar position using **class modifiers** in the `as-app` element.
 
 > This modifiers wont affect mobile screens where the toolbar is always displayed on top.
 
-### .as-app-nav--left
+### .as-app-nav\--left
 
 
 
@@ -25,7 +25,7 @@ showSource: true
 </div>
 ```
 
-### .as-app-nav--right
+### .as-app-nav\--right
 
 
 
@@ -140,13 +140,13 @@ showSource: true
   </nav>
 </header>
 ```
-#### .as-toolbar__actions--visible
+#### .as-toolbar__actions\--visible
 
 Use this class modifier to display the toolbar-actions menu on small screens.
 
 ### .as-toolbar__toggle
 
-Use the `.as-toolbar__togle` modifier to create a button that controls the menu visibility.
+Use the `.as-toolbar__toggle` modifier to create a button that controls the menu visibility.
 
 
 ```html


### PR DESCRIPTION
By default, Markdown parser in catalog converts `--` to `―`, making it difficult to understand CSS variables or CSS classes characters.

Fixes #349.