### PR TITLE
Set proper format for guide paragraphs

### DIFF
--- a/docs/guides/05-web-components.md
+++ b/docs/guides/05-web-components.md
@@ -1,4 +1,4 @@
-### Web components
+## Web components
 
 Airship provides a set of [web components](https://www.webcomponents.org/introduction). One of the key features of the Web Components standard is the ability to offer custom elements that encapsulate functionality on an HTML page, rather than having to make do with a long, nested batch of elements that together provide a custom page feature.
 
@@ -13,9 +13,9 @@ This is especially interesting to create geospatial widgets, such as a histogram
 </as-category-widget>
 ```
 
-**Attributes**
+### Attributes
 
-[Attributes](https://en.wikipedia.org/wiki/HTML_attribute) modify the default functionality of an element. The attributes will usually have a default value and using them will be optional. In the example above, heading and description are required attributes while the bar color is optional. 
+[Attributes](https://en.wikipedia.org/wiki/HTML_attribute) modify the default functionality of an element. The attributes will usually have a default value and using them will be optional. In the example above, heading and description are required attributes while the bar color is optional.
 
 HTML Attributes can only be `strings` so if you want to use an object as an attribute you need to use javascript to get access to the element and set up the attribute via code.
 
@@ -33,7 +33,7 @@ const categoriesList = [
 $categoryWidget.categories = categoriesList;
 ```
 
-**Loading web components**
+### Loading web components
 
 Loading and using web components is very easy, you just need to include our component loader in the head of your app. Once the loader is included, it will automatically detect the use of web-components and load them on demand. It also detects browser capabilities and will automatically decide whether or not to include polyfills, leading to smaller bundles in modern browsers.
 
@@ -50,11 +50,11 @@ Loading and using web components is very easy, you just need to include our comp
 
 > The loader may conflict with the webpack bundler if the [publicPath](https://webpack.js.org/guides/public-path/) property is not configured correctly.
 
-**List of Web Components**
+### List of Web Components
 
 > See the most recent list in [the reference](/developers/airship/reference)
 
-**Framework integration**
+### Framework integration
 
 You can use Airship components with another web frameworks like Angular, React or Vue. See [https://stenciljs.com/docs/overview/](https://stenciljs.com/docs/overview/).
 
@@ -63,7 +63,7 @@ You can use Airship components with another web frameworks like Angular, React o
   - [Airship and React](/developers/airship/guides/integrating-react/)
   - [Airship and Vue](/developers/airship/guides/integrating-Vue/)
 
-**Browser support**
+### Browser support
 
 Airship Components are build with Stencil, that run natively or near-natively in all widely used browsers.
 

--- a/docs/guides/09-integrating-CARTO-VL.md
+++ b/docs/guides/09-integrating-CARTO-VL.md
@@ -1,8 +1,10 @@
+## Advanced guide: Using Airship with CARTO-VL
+
 In this guide, you will learn how to create a map and a Category Widget showing data coming from the map, and reacting to changes in the map, as well as filtering data by using Category Widget.
 
 We'll use [CARTO-VL](https://carto.com/developers/carto-vl/) and Airship to show how they work together properly.
 
-## Airship setup
+### Airship setup
 
 Let's start from scratch creating an empty `index.html` file with this scaffolding for this guide.
 
@@ -18,7 +20,7 @@ Let's start from scratch creating an empty `index.html` file with this scaffoldi
 </html>
 ```
 
-## Including Airship
+### Including Airship
 
 To use Airship styles and components we need to include them in our HTML. Since we just want to create a simple app we are going to include Airship components and styles through a CDN by including the following snippet in the `<head>` of our application:
 
@@ -31,7 +33,7 @@ To use Airship styles and components we need to include them in our HTML. Since 
 <script src="https://libs.cartocdn.com/airship-components/%AS-VERSION%/airship.js"></script>
 ```
 
-## Including CARTO-VL
+### Including CARTO-VL
 
 As pointed in the [CARTO-VL docs](https://carto.com/developers/carto-vl/guides/getting-started/) we can also include CARTO-VL in our app using a CDN
 
@@ -47,7 +49,7 @@ As pointed in the [CARTO-VL docs](https://carto.com/developers/carto-vl/guides/g
 ```
 
 
-## Setting a basic layout
+### Setting a basic layout
 
 A basic layout will just include a container for our map and a sidebar for our future widget.
 
@@ -69,7 +71,7 @@ In this case we add a `as-map-area` where the map will be displayed and a `as-si
 ```
 
 
-## Drawing a map with CARTO-VL
+### Drawing a map with CARTO-VL
 For this guide we are going to use the js code of the [CARTO-VL basic example](https://carto.com/developers/carto-vl/examples/#example-add-carto-dataset-layer) at this point you should see a map with an white space on the right.
 
 ```html
@@ -109,7 +111,7 @@ For this guide we are going to use the js code of the [CARTO-VL basic example](h
 </script>
 ```
 
-## Adding a Category Widget
+### Adding a Category Widget
 
 Adding a Category Widget is as simple as including `<as-category-widget>` tag within our `as-sidebar` element, setting the options you prefer.
 
@@ -123,7 +125,7 @@ Adding a Category Widget is as simple as including `<as-category-widget>` tag wi
 </aside>
 ```
 
-### Binding CARTO-VL data
+#### Binding CARTO-VL data
 
 The category widget will not show any data unless we provide them. For this example, we will simply show the list sorted by the maximum population of cities that can be seen on the map.
 
@@ -161,6 +163,6 @@ function updateWidgets() {
   };
 ```
 
-### Reacting to data changes
+#### Reacting to data changes
 
 > TODO

--- a/docs/guides/10-integrating-react.md
+++ b/docs/guides/10-integrating-react.md
@@ -1,10 +1,12 @@
+## Integration guide: Using Airship with React
+
 This guide will lead you through the process of integrating Airship in [React.js](https://reactjs.org/).
 
 >  We are working on React bindings that offer a better developer experience in the future.
 
-## Including Styles
+### Including Styles
 
-Install `airship-style` package and 
+Install `airship-style` package and
 
  ```
 npm i @carto/airship-style
@@ -16,7 +18,7 @@ Load the styles into your code
 @import '@carto/airship-style/dist/airship.css';
 ```
 
-## Web components
+### Web components
 
 A web component is just an HTML tag with some attributes that control its behaviour. Simply include the HTML tag, and edit its properties through attributes or through javascript as you would do with a normal HTML element.
 
@@ -30,9 +32,9 @@ render() {
 ```
 
 
-## Loading web components
+#### Loading web components
 
-Install `airship-components` package 
+Install `airship-components` package
 
 ```
 npm i @carto/airship-components
@@ -47,7 +49,7 @@ defineCustomElements(window);
 
 In order to manage the state, either listening to events or synchronizing the attributes we got two options.
 
-## Option 1: Manage component logic in the parent layer.
+#### Option 1: Manage component logic in the parent layer.
 
 The simplest way to link Airship and React is to manually bind attributes and events. [Content attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#Content_versus_IDL_attributes) only accept strings as parameters so we need to
 use javascript to add event listeners and pass complex objects as parameter.
@@ -119,7 +121,7 @@ export default class App extends Component {
 ```
 
 
-## Option 2: Wrap the component into a react element
+#### Option 2: Wrap the component into a react element
 
 With this option we are going to create a React component that wraps the original web-component exposing a simple and react-friendly API.
 
@@ -139,7 +141,7 @@ export default class CategoryWidget extends Component {
   }
 
   render() {
-    <as-category-widget 
+    <as-category-widget
       ref={this.ref}
       heading={this.props.heading}
       description={this.props.description}

--- a/docs/guides/11-integrating-Angular.md
+++ b/docs/guides/11-integrating-Angular.md
@@ -1,6 +1,7 @@
+## Integration guide: Using Airship with Angular
 This guide will lead you through the process of integrating Airship in [Angular](https://angular.io).
 
-## Including Styles
+### Including Styles
 We need to import styles in main `styles.css` file from npm package. Styles inside that file are meant to be global, hence we need to import Airship styles there so that CSS Variables are globally defined.
 
 ```
@@ -12,7 +13,7 @@ To import the styles, we need to include `airship.css` in the file:
 @import '~@carto/airship-style/dist/airship.css';
 ```
 
-## Integrating Web Components
+### Integrating Web Components
 Web Components are natively supported in Angular, so the syntax resembles to the one in native components.
 
 First, we need to import `CUSTOM_ELEMENTS_SCHEMA` in our main application module, or just in the modules that use Web Components if you prefer.
@@ -39,7 +40,7 @@ export class AppModule { }
 
 As you can see, **CUSTOM_ELEMENTS_SCHEMA** property comes from `@angular/core` and is injected into `schemas` property in the module declaration. This schema will allow you to use custom elements in your Angular templates without raising any exceptions.
 
-### Using Web Components in templates
+#### Using Web Components in templates
 To add a Web Component to any Angular template you just need to use the HTML syntax that is provided in the reference.
 
 ```html
@@ -50,7 +51,7 @@ To add a Web Component to any Angular template you just need to use the HTML syn
   (categoriesSelected)="onCategorySelected($event)"></as-category-widget>
 ```
 
-#### Passing properties to component
+##### Passing properties to component
 You can pass all the properties and listen to all the events via HTML.
 
 If the property is a number or a text that will be harcoded in the template, you will pass it as a regular HTML property.
@@ -77,7 +78,7 @@ Event listeners are attached to the component in the same way as you would do wi
 <as-category-widget (categoriesSelected)="onCategorySelected($event)"></as-category-widget>
 ```
 
-### Invoking component methods
+#### Invoking component methods
 Components have some methods to be called from outside the web component. To do that, you need to retrieve the elements' reference with `ViewChild` decorator.
 
 ```ts

--- a/docs/guides/12-integrating-Vue.md
+++ b/docs/guides/12-integrating-Vue.md
@@ -1,6 +1,7 @@
+## Integration guide: Using Airship with Vue
 This guide will lead you through the process of integrating Airship with [Vue](https://vuejs.org/).
 
-## Including Styles
+### Including Styles
 Airship styles need to be globally included within our Vue application, so that we can use styles everywhere instead of including them inside any component scope. We are going to import them in the application's entry point via npm.
 
 ```
@@ -27,7 +28,7 @@ You will need to tell Webpack to use these loaders by changing the configuration
 }
 ```
 
-## Integrating Web Components
+### Integrating Web Components
 On top of adding Airship styles, we need to load our components into your application. You can do it below our styles import in the main entry point of the application.
 
 First, we need to tell Vue to ignore elements starting with `as-`, which are our Airship components. We don't want Vue to raise an error everytime an Airship component is included in a template.
@@ -45,7 +46,7 @@ import { defineCustomElements } from '@carto/airship-components';
 defineCustomElements(window);
 ```
 
-### Using Web Components in templates
+#### Using Web Components in templates
 To add a Web Component to a Vue template you just need to use the HTML syntax that is provided in the reference.
 
 Although Web Components are supported in Vue, there's one caveat when it comes to injecting data into the component. The only properties that can be passed via attributes are text and number properties, whether via direct text or injecting the property in the template.
@@ -59,7 +60,7 @@ Although Web Components are supported in Vue, there's one caveat when it comes t
 
 To pass complex properties such as Objects and Arrays or listen to component events, you need to do it via Vue element reference or creating a mirror component.
 
-#### Managing component with element reference
+##### Managing component with element reference
 There are some properties that we cannot pass or events that we cannot listen to in the example above, such as category property or categoriesSelected event.
 
 To get the element reference, we need to set `ref` property in the component template node.
@@ -76,7 +77,7 @@ To get the element reference, we need to set `ref` property in the component tem
 
 Element's reference will be in our Vue component's `refs` property, hence we will have full access to our Airship component.
 
-##### Listening to component events
+###### Listening to component events
 The best way to listen to component events is in `mounted` function in your desired component.
 
 ```js
@@ -96,7 +97,7 @@ We create an easy-to-use reference to the widget so that we can reuse it in othe
 
 It will only listen once to component event and it won't create multiple unneeded event listeners by doing it in `mounted` callback.
 
-##### Passing complex properties to component
+###### Passing complex properties to component
 The way to pass complex properties to the component is very similar to listening to events.
 
 To make the component react to property changes we need to create a watch over the property that holds our data. Once `watch` is ready, we need to set the new value of the property to the desired property in the component, like:
@@ -112,7 +113,7 @@ export default {
 }
 ```
 
-##### Invoking component methods
+###### Invoking component methods
 To invoke a component method, we need to create a mirror method in our Vue component that executes the original method.
 
 ```js
@@ -129,7 +130,7 @@ export default {
 }
 ```
 
-### Mirroring Web Components with Vue component
+#### Mirroring Web Components with Vue component
 Mirroring one Airship Component with a Vue component is pretty much like doing the same things as above but encapsulated within a single component.
 
 To mirror the Airship Component, we need to create a new Vue component like this:


### PR DESCRIPTION
I saw that some of the paragraph titles on the guides were very big, so here's the fix. Please add some other wrong paragraphs that you see.