### PR TITLE
Set proper encoding when reading files to upload

### DIFF
--- a/scripts/release-s3.js
+++ b/scripts/release-s3.js
@@ -115,7 +115,7 @@ async function uploadAllFiles (dir, version, destination, subfolder='') {
       objectConfig.ContentType = mime.getType(filePath);
 
       try {
-        fileContent = await readFile(filePath);
+        fileContent = await readFile(filePath, { encoding: 'utf8' });
         fileLength = fileContent.length;
 
         if (shouldZip(extension)) {


### PR DESCRIPTION
I noticed the other day that a character we introduced in the BANNER file was not being properly shown in S3 file.

I think that was because the uploaded files were not being read with the proper encoding, so this PR fixes that, hopefully.

<img width="374" alt="screen shot 2018-10-05 at 12 36 42" src="https://user-images.githubusercontent.com/4319728/46530874-7bf5ea00-c89b-11e8-8115-055806bcfba5.png">
