### PR TITLE
Remove version number from banner in bundles

### DIFF
--- a/packages/components/stencil.config.js
+++ b/packages/components/stencil.config.js
@@ -23,8 +23,5 @@ exports.config = {
       ]
     })
   ],
-  preamble: [
-    'Airship Components · CARTO · https://carto.com',
-    `Version ${version}`
-  ].join('\n')
+  preamble: 'Airship Components · CARTO · https://carto.com'
 };

--- a/packages/styles/scripts/add-banner.js
+++ b/packages/styles/scripts/add-banner.js
@@ -6,7 +6,6 @@ const fs = require('fs');
 
 const banner = `/*!
 * Airship Styles · CARTO · https://carto.com
-* Version ${version}
 * ${new Date().toISOString()}
 */
 `;

--- a/packages/styles/scripts/add-banner.sh
+++ b/packages/styles/scripts/add-banner.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-BANNER=$(node scripts/add-banner.js)
-SUBSTITUTION_COMMAND="${BANNER}"
-# echo "$SUBSTITUTION_COMMAND"
-find dist/ -type f -name '*.css' -exec bash -c 'echo "${SUBSTITUTION_COMMAND}"' - '{}' \;
-# sed -i "" "1s;^;${BANNER};" "$1"
-# echo "$BANNER"


### PR DESCRIPTION
We were adding version number to Airship bundles' banner. But as version number is bumped right before uploading, it was injecting the previous version number, so we decided to remove it and leave release date.