### PR TITLE
Avoid checking TouchEvent to fix Range Slider in Safari

### DIFF
--- a/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
+++ b/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
@@ -117,7 +117,9 @@ export class RangeSliderThumb extends MouseTrack {
 
   private _onMove(event: MouseEvent | TouchEvent) {
     this.setCursorTo('grabbing');
-    const eventX = event instanceof TouchEvent ? event.changedTouches[0].pageX : event.pageX;
+
+    const changedTouches = (event as TouchEvent).changedTouches;
+    const eventX = changedTouches ? changedTouches[0].pageX : (event as MouseEvent).pageX;
     const barPercentage = (eventX - this.railBoundingClientRect.left) * 100 / this.railElement.offsetWidth;
 
     if (barPercentage < 0 || barPercentage > 100) {

--- a/packages/components/src/components/as-range-slider/track/as-range-slider-bar.tsx
+++ b/packages/components/src/components/as-range-slider/track/as-range-slider-bar.tsx
@@ -135,13 +135,16 @@ export class RangeSliderBar extends MouseTrack {
   }
 
   private _getMovementDelta(currentEvent: MouseEvent | TouchEvent, previousEvent: MouseEvent | TouchEvent) {
-    const currentEventX = currentEvent instanceof TouchEvent
-      ? currentEvent.changedTouches[0].pageX
-      : currentEvent.pageX;
+    const currentChangedTouches = (currentEvent as TouchEvent).changedTouches;
+    const previousChangedTouches = (previousEvent as TouchEvent).changedTouches;
 
-    const previousEventX = previousEvent instanceof TouchEvent
-    ? previousEvent.changedTouches[0].pageX
-    : previousEvent.pageX;
+    const currentEventX = currentChangedTouches
+      ? currentChangedTouches[0].pageX
+      : (currentEvent as MouseEvent).pageX;
+
+    const previousEventX = previousChangedTouches
+      ? previousChangedTouches[0].pageX
+      : (previousEvent as MouseEvent).pageX;
 
     return currentEventX - previousEventX;
   }


### PR DESCRIPTION
We introduced a check of `TouchEvent` variable to distinguish between Desktop and Mobile events. Seems like that `TouchEvent` variable is not defined in Safari, leading to errors when dragging Range Slider's thumb.