### PR TITLE
Fix Inception in dev reference

### DIFF
--- a/catalog/index.html
+++ b/catalog/index.html
@@ -41,7 +41,7 @@
     window.onclick = function (event) {
       var target = event && event.target;
       if (target && target.nodeName && target.nodeName.toUpperCase() === "A") {
-        if (target.href.indexOf('#') < 0) {
+        if (target.href && target.href.indexOf('#') < 0) {
           sendMessage(target.href);
         }
       }

--- a/catalog/index.html
+++ b/catalog/index.html
@@ -40,7 +40,7 @@
 
     window.onclick = function (event) {
       var target = event && event.target;
-      if (target && target.nodeName.toUpperCase() === "A") {
+      if (target && target.nodeName && target.nodeName.toUpperCase() === "A") {
         if (target.href.indexOf('#') < 0) {
           sendMessage(target.href);
         }

--- a/catalog/index.html
+++ b/catalog/index.html
@@ -38,6 +38,15 @@
       sendMessage(event.newURL);
     };
 
+    window.onclick = function (event) {
+      var target = event && event.target;
+      if (target && target.nodeName.toUpperCase() === "A") {
+        if (target.href.indexOf('#') < 0) {
+          sendMessage(target.href);
+        }
+      }
+    }
+
     Catalog.render({
       title: 'Airship',
       useBrowserHistory: false,


### PR DESCRIPTION
This PR fixes `inception` in dev center. Where a click on an absolute link only changes the iframe contents.

It listen on any click on anchor tags, see if it's not a hash URL and send the message to the iframe listener.

The listener is on the `developers` PR https://github.com/CartoDB/developers/pull/445

![image](https://user-images.githubusercontent.com/1078228/46806089-ff657e80-cd66-11e8-9d1e-750f151797b7.png)
