### PR TITLE
Add body class

### DIFF
--- a/docs/guides/01-introduction.md
+++ b/docs/guides/01-introduction.md
@@ -31,29 +31,31 @@ The easiest way to include Airship is through our CDN, adding the tags in the he
   <!-- Include Mapbox GL CSS -->
   <link href="https://libs.cartocdn.com/mapbox-gl/v0.48.0-carto1/mapbox-gl.css" rel="stylesheet" />
 </head>
-<body class="as-app">
+<body class="as-app-body">
 
-  <header class="as-toolbar"></header>
-  <nav class="as-tabs"></nav>
+  <div class="as-app">
+    <header class="as-toolbar"></header>
+    <nav class="as-tabs"></nav>
 
-  <div class="as-content">
-    <aside class="as-sidebar as-sidebar--left"></aside>
+    <div class="as-content">
+      <aside class="as-sidebar as-sidebar--left"></aside>
 
-    <main class="as-main">
-      <div class="as-map-area">
-        <div id="map"></div>
+      <main class="as-main">
+        <div class="as-map-area">
+          <div id="map"></div>
 
-        <div class="as-map-panels">
-          <div class="as-panel as-panel--top as-panel--right">
-            <div class="as-panel__element as-p--32 as-bg--support-02"></div>
+          <div class="as-map-panels">
+            <div class="as-panel as-panel--top as-panel--right">
+              <div class="as-panel__element as-p--32 as-bg--support-02"></div>
+            </div>
           </div>
+
         </div>
+        <footer class="as-map-footer as-bg--complementary" style="height: 100px;"></footer>
+      </main>
 
-      </div>
-      <footer class="as-map-footer as-bg--complementary" style="height: 100px;"></footer>
-    </main>
-
-    <aside class="as-sidebar as-sidebar--right"></aside>
+      <aside class="as-sidebar as-sidebar--right"></aside>
+    </div>
   </div>
 
   <!-- CARTO basemap -->

--- a/docs/guides/02-getting-started.md
+++ b/docs/guides/02-getting-started.md
@@ -145,29 +145,31 @@ For example a range slider
   <!-- Include airship components -->
   <script src="https://libs.cartocdn.com/airship-components/%AS-VERSION%/airship.js"></script>
 </head>
-<body class="as-app">
+<body class="as-app-body">
 
-  <header class="as-toolbar"></header>
-  <nav class="as-tabs"></nav>
+  <div class="as-app">
+    <header class="as-toolbar"></header>
+    <nav class="as-tabs"></nav>
 
-  <div class="as-content">
-    <aside class="as-sidebar as-sidebar--left"></aside>
+    <div class="as-content">
+      <aside class="as-sidebar as-sidebar--left"></aside>
 
-    <main class="as-main">
-      <div class="as-map-area">
-        <div id="map"></div>
+      <main class="as-main">
+        <div class="as-map-area">
+          <div id="map"></div>
 
-        <div class="as-map-panels">
-          <div class="as-panel as-panel--top as-panel--right">
-            <div class="as-panel__element as-p--32 as-bg--support-02"></div>
+          <div class="as-map-panels">
+            <div class="as-panel as-panel--top as-panel--right">
+              <div class="as-panel__element as-p--32 as-bg--support-02"></div>
+            </div>
           </div>
+
         </div>
+        <footer class="as-map-footer as-bg--complementary" style="height: 100px;"></footer>
+      </main>
 
-      </div>
-      <footer class="as-map-footer as-bg--complementary" style="height: 100px;"></footer>
-    </main>
-
-    <aside class="as-sidebar as-sidebar--right"></aside>
+      <aside class="as-sidebar as-sidebar--right"></aside>
+    </div>
   </div>
 
   <!-- Basic CARTO-VL MAP -->

--- a/docs/guides/07-layout.md
+++ b/docs/guides/07-layout.md
@@ -45,29 +45,30 @@ We provide some responsive utilities by default, for example `sidebars` are hidd
   <!-- Include airship components -->
   <script src="https://libs.cartocdn.com/airship-components/%AS-VERSION%/airship.js"></script>
 </head>
-<body class="as-app">
+<body class="as-app-body">
+  <div class="as-app">
+    <header class="as-toolbar"></header>
+    <nav class="as-tabs"></nav>
 
-  <header class="as-toolbar"></header>
-  <nav class="as-tabs"></nav>
+    <div class="as-content">
+      <aside class="as-sidebar as-sidebar--left"></aside>
 
-  <div class="as-content">
-    <aside class="as-sidebar as-sidebar--left"></aside>
+      <main class="as-main">
+        <div class="as-map-area">
+          <div id="map"></div>
 
-    <main class="as-main">
-      <div class="as-map-area">
-        <div id="map"></div>
-
-        <div class="as-map-panels">
-          <div class="as-panel as-panel--top as-panel--right">
-            <div class="as-panel__element as-p--32 as-bg--support-02"></div>
+          <div class="as-map-panels">
+            <div class="as-panel as-panel--top as-panel--right">
+              <div class="as-panel__element as-p--32 as-bg--support-02"></div>
+            </div>
           </div>
+
         </div>
+        <footer class="as-map-footer as-bg--complementary" style="height: 100px;"></footer>
+      </main>
 
-      </div>
-      <footer class="as-map-footer as-bg--complementary" style="height: 100px;"></footer>
-    </main>
-
-    <aside class="as-sidebar as-sidebar--right"></aside>
+      <aside class="as-sidebar as-sidebar--right"></aside>
+    </div>
   </div>
 
   <!-- Basic CARTO-VL MAP -->

--- a/docs/guides/09-integrating-CARTO-VL.md
+++ b/docs/guides/09-integrating-CARTO-VL.md
@@ -16,7 +16,7 @@ Let's start from scratch creating an empty `index.html` file with this scaffoldi
       <meta name="viewport" content="width=device-width,initial-scale=1.0">
       <meta http-equiv="X-UA-Compatible" content="ie=edge">
   </head>
-   <body class="as-app"></body>
+   <body class="as-app-body"></body>
 </html>
 ```
 
@@ -58,16 +58,18 @@ An airship app always has a container for our main content with `.as-content` cl
 In this case we add a `as-map-area` where the map will be displayed and a `as-sidebar` to contain our widgets.
 
  ```html
-<div class="as-content">
-  <main class="as-main">
-    <div class="as-map-area">
-      <div id="map"></div>
-    </div>
-  </main>
-  <aside class="as-sidebar as-sidebar--right">
+<div class="as-app">
+  <div class="as-content">
+    <main class="as-main">
+      <div class="as-map-area">
+        <div id="map"></div>
+      </div>
+    </main>
+    <aside class="as-sidebar as-sidebar--right">
 
-  </aside>
+    </aside>
   </div>
+</div>
 ```
 
 

--- a/docs/guides/10-Integrating-CARTOjs.md
+++ b/docs/guides/10-Integrating-CARTOjs.md
@@ -17,7 +17,7 @@ Let's start from scratch creating an empty `index.html` file with this scaffoldi
       <meta http-equiv="X-UA-Compatible" content="ie=edge">
   </head>
 
-  <body class="as-app">
+  <body class="as-app-body">
 
   </body>
 </html>
@@ -44,15 +44,17 @@ The layout will always be wrapped by a block element with `.as-content` class, w
 So, to create our layout we need a right sidebar and a block element wrapped by `.as-map-wrapper` class for our map.
 
 ```html
-<div class="as-content">
-  <main class="as-main">
-    <div class="as-map-area">
-      <div id="map"></div>
-    </div>
-  </main>
+<div class="as-app">
+  <div class="as-content">
+    <main class="as-main">
+      <div class="as-map-area">
+        <div id="map"></div>
+      </div>
+    </main>
 
-  <aside class="as-sidebar as-sidebar--right">
-  </aside>
+    <aside class="as-sidebar as-sidebar--right">
+    </aside>
+  </div>
 </div>
 ```
 
@@ -232,20 +234,22 @@ Using that Bounding Box filter, our widget will be automatically updated wheneve
       </style>
   </head>
 
-  <body class="as-app">
-    <div class="as-content">
-      <main class="as-main">
-        <div class="as-map-area">
-          <div id="map"></div>
-        </div>
-      </main>
+  <body class="as-app-body">
+    <div class="as-app">
+      <div class="as-content">
+        <main class="as-main">
+          <div class="as-map-area">
+            <div id="map"></div>
+          </div>
+        </main>
 
-      <aside class="widgets as-sidebar as-sidebar--right as-sidebar">
-          <as-category-widget
-          heading="Populated places"
-          description="Top populated cities ordered by descending population"
-          default-bar-color="#47DB99"></as-category-widget>
-      </aside>
+        <aside class="widgets as-sidebar as-sidebar--right as-sidebar">
+            <as-category-widget
+            heading="Populated places"
+            description="Top populated cities ordered by descending population"
+            default-bar-color="#47DB99"></as-category-widget>
+        </aside>
+      </div>
     </div>
 
     <script>

--- a/examples/components/as-responsive-content/custom-order.html
+++ b/examples/components/as-responsive-content/custom-order.html
@@ -21,7 +21,7 @@
   <!-- / CARTO.js -->
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <as-responsive-content>
     <aside class="as-sidebar as-sidebar--left" data-name="Stores" data-tab-order="2">
       <div class="as-container">

--- a/examples/components/as-responsive-content/simple.html
+++ b/examples/components/as-responsive-content/simple.html
@@ -21,7 +21,7 @@
   <!-- / CARTO.js -->
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <as-responsive-content>
     <aside class="as-sidebar as-sidebar--left" data-name="Stores">
       <div class="as-container">

--- a/examples/containers/containers-bottom.html
+++ b/examples/containers/containers-bottom.html
@@ -17,7 +17,7 @@
   <!-- / CARTO.js -->
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showBottomPanel(event)" role="tab" class="as-tabs__item">BOTTOM</button>

--- a/examples/containers/containers-colors.html
+++ b/examples/containers/containers-colors.html
@@ -18,7 +18,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showRightPanel(event)" role="tab" class="as-tabs__item">RIGHT</button>

--- a/examples/containers/containers-legends.html
+++ b/examples/containers/containers-legends.html
@@ -19,7 +19,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showLegendsPanel(event); setActiveTab(event.target);" role="tab" class="as-tabs__item">LEGENDS</button>

--- a/examples/containers/containers-sidebar.html
+++ b/examples/containers/containers-sidebar.html
@@ -18,7 +18,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showRightPanel(event)" role="tab" class="as-tabs__item">RIGHT</button>

--- a/examples/containers/containers.html
+++ b/examples/containers/containers.html
@@ -18,7 +18,7 @@
   <!-- / CARTO.js -->
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showRightPanel(event)" role="tab" class="as-tabs__item">RIGHT</button>

--- a/examples/layouts/basic-layout.html
+++ b/examples/layouts/basic-layout.html
@@ -31,7 +31,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
 
   <header class="as-toolbar">
     <div class="as-toolbar__item as-title">TOOLBAR</div>

--- a/examples/layouts/containers/containers.html
+++ b/examples/layouts/containers/containers.html
@@ -16,7 +16,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <main class="as-main">
       <div class="as-map-area">

--- a/examples/layouts/footer/footer.html
+++ b/examples/layouts/footer/footer.html
@@ -20,7 +20,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <nav role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showBottom(event)" role="tab" class="as-tabs__item">FOOTER</button>

--- a/examples/layouts/panels/panels-tabs.html
+++ b/examples/layouts/panels/panels-tabs.html
@@ -16,7 +16,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <nav role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showLegendsPanel(event)" role="tab" class="as-tabs__item">PANELS</button>

--- a/examples/layouts/panels/panels.html
+++ b/examples/layouts/panels/panels.html
@@ -16,7 +16,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <main class="as-main">
       <div class="as-map-area">

--- a/examples/layouts/sidebar/sidebar-left-l.html
+++ b/examples/layouts/sidebar/sidebar-left-l.html
@@ -20,7 +20,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <nav role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showLeft(event)" role="tab" class="as-tabs__item">LEFT</button>

--- a/examples/layouts/sidebar/sidebar-left.html
+++ b/examples/layouts/sidebar/sidebar-left.html
@@ -20,7 +20,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <nav role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showLeft(event)" role="tab" class="as-tabs__item">LEFT</button>

--- a/examples/layouts/sidebar/sidebar-right-xl.html
+++ b/examples/layouts/sidebar/sidebar-right-xl.html
@@ -20,7 +20,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <nav role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showLeft(event)" role="tab" class="as-tabs__item">LEFT</button>

--- a/examples/layouts/sidebar/sidebar-right.html
+++ b/examples/layouts/sidebar/sidebar-right.html
@@ -20,7 +20,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <nav role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showLeft(event)" role="tab" class="as-tabs__item">LEFT</button>

--- a/examples/layouts/sidebar/sidebar.html
+++ b/examples/layouts/sidebar/sidebar.html
@@ -20,7 +20,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <nav role="tablist" class="as-toolbar-tabs as-tabs">
     <button onclick="showMap(event)" role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button onclick="showLeft(event)" role="tab" class="as-tabs__item">LEFT</button>

--- a/examples/layouts/tabs/tabs.html
+++ b/examples/layouts/tabs/tabs.html
@@ -16,7 +16,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
 
   <header class="as-toolbar"></header>
 

--- a/examples/layouts/toolbar/toggle.html
+++ b/examples/layouts/toolbar/toggle.html
@@ -29,29 +29,31 @@
 
 </script>
 
-<body class="as-app as-app--nav-top">
-  <header class="as-toolbar">
-    <button onclick="toggleDrawer()" class="as-toolbar__item as-toolbar__toggle">
-      <i class="as-icon-hamburguer as-title as-m--0"></i>
-    </button>
-    <div href="#" class="as-toolbar__item">LOGO</div>
-    <nav class="as-toolbar__actions">
-      <ul>
-        <li>
-          <a href="#" class="as-toolbar__item">Link 1</a>
-        </li>
-        <li>
-          <a href="#" class="as-toolbar__item">Link 2</a>
-        </li>
-      </ul>
-    </nav>
-  </header>
+<body class="as-app-body">
+  <div class="as-app as-app--nav-top">
+    <header class="as-toolbar">
+      <button onclick="toggleDrawer()" class="as-toolbar__item as-toolbar__toggle">
+        <i class="as-icon-hamburguer as-title as-m--0"></i>
+      </button>
+      <div href="#" class="as-toolbar__item">LOGO</div>
+      <nav class="as-toolbar__actions">
+        <ul>
+          <li>
+            <a href="#" class="as-toolbar__item">Link 1</a>
+          </li>
+          <li>
+            <a href="#" class="as-toolbar__item">Link 2</a>
+          </li>
+        </ul>
+      </nav>
+    </header>
 
-  <main class="as-app-content">
-    <div class="as-map-wrapper">
-      <div id="map"></div>
-    </div>
-  </main>
+    <main class="as-app-content">
+      <div class="as-map-wrapper">
+        <div id="map"></div>
+      </div>
+    </main>
+  </div>
 
   <script defer src="../common/map.js"></script>
   <script defer src="../common/tabs.js"></script>

--- a/examples/layouts/toolbar/toolbar-left.html
+++ b/examples/layouts/toolbar/toolbar-left.html
@@ -14,16 +14,18 @@
   <link href="https://libs.cartocdn.com/mapbox-gl/v0.48.0-carto1/mapbox-gl.css" rel="stylesheet" />
 </head>
 
-<body class="as-app as-app--nav-left">
+<body class="as-app-body">
 
-  <header class="as-toolbar"></header>
+  <div class="as-app as-app--nav-left">
+    <header class="as-toolbar"></header>
 
-  <div class="as-content">
-    <main class="as-main">
-      <div class="as-map-area">
-        <div id="map"></div>
-      </div>
-    </main>
+    <div class="as-content">
+      <main class="as-main">
+        <div class="as-map-area">
+          <div id="map"></div>
+        </div>
+      </main>
+    </div>
   </div>
 
   <!-- Basic CARTO-VL MAP -->

--- a/examples/layouts/toolbar/toolbar-right.html
+++ b/examples/layouts/toolbar/toolbar-right.html
@@ -14,17 +14,18 @@
   <link href="https://libs.cartocdn.com/mapbox-gl/v0.48.0-carto1/mapbox-gl.css" rel="stylesheet" />
 </head>
 
-<body class="as-app as-app--nav-right">
+<body class="as-app-body">
+  <div class="as-app as-app--nav-right">
 
-  <header class="as-toolbar"></header>
+    <header class="as-toolbar"></header>
 
-
-  <div class="as-content">
-    <main class="as-main">
-      <div class="as-map-area">
-        <div id="map"></div>
-      </div>
-    </main>
+    <div class="as-content">
+      <main class="as-main">
+        <div class="as-map-area">
+          <div id="map"></div>
+        </div>
+      </main>
+    </div>
   </div>
 
   <!-- Basic CARTO-VL MAP -->

--- a/examples/layouts/toolbar/toolbar-top.html
+++ b/examples/layouts/toolbar/toolbar-top.html
@@ -14,7 +14,7 @@
   <link href="https://libs.cartocdn.com/mapbox-gl/v0.48.0-carto1/mapbox-gl.css" rel="stylesheet" />
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
 
   <header class="as-toolbar"></header>
 

--- a/examples/layouts/toolbar/toolbar.html
+++ b/examples/layouts/toolbar/toolbar.html
@@ -23,47 +23,49 @@
 
 </head>
 
-<body class="as-app as-app--nav-top">
-  <header class="as-toolbar">
-    <button onclick="_toggleDrawer()" class="as-toolbar__item as-toolbar__toggle">
-      <i class="as-icon-hamburguer as-title as-m--0"></i>
-    </button>
+<body class="as-app-body">
+  <div class="as-app as-app--nav-top">
+    <header class="as-toolbar">
+      <button onclick="_toggleDrawer()" class="as-toolbar__item as-toolbar__toggle">
+        <i class="as-icon-hamburguer as-title as-m--0"></i>
+      </button>
 
-    <div class="as-toolbar__group">
-      <div class="as-toolbar__item">
-        <img src="../common/logo.svg" alt="CARTO LOGO">
+      <div class="as-toolbar__group">
+        <div class="as-toolbar__item">
+          <img src="../common/logo.svg" alt="CARTO LOGO">
+        </div>
+
+        <nav class="as-toolbar__actions">
+          <ul>
+            <li class="as-toolbar__item">
+              <a href="http://www.carto.com">Home</a>
+            </li>
+            <li class="as-toolbar__item">
+              <a href="http://www.carto.com">About</a>
+            </li>
+            <li class="as-toolbar__item">
+              <i class="as-icon-magnify as-subheader as-m--0"></i>
+              <p class="as-toolbar__icon-text">Search</p>
+            </li>
+            <li class="as-toolbar__item">
+              <i class="as-icon-info as-subheader as-m--0"></i>
+              <p class="as-toolbar__icon-text">Help</p>
+            </li>
+            <li class="as-toolbar__item">
+              <i class="as-icon-twitter as-subheader as-m--0"></i>
+              <p class="as-toolbar__icon-text">Twitter</p>
+            </li>
+          </ul>
+        </nav>
       </div>
+    </header>
 
-      <nav class="as-toolbar__actions">
-        <ul>
-          <li class="as-toolbar__item">
-            <a href="http://www.carto.com">Home</a>
-          </li>
-          <li class="as-toolbar__item">
-            <a href="http://www.carto.com">About</a>
-          </li>
-          <li class="as-toolbar__item">
-            <i class="as-icon-magnify as-subheader as-m--0"></i>
-            <p class="as-toolbar__icon-text">Search</p>
-          </li>
-          <li class="as-toolbar__item">
-            <i class="as-icon-info as-subheader as-m--0"></i>
-            <p class="as-toolbar__icon-text">Help</p>
-          </li>
-          <li class="as-toolbar__item">
-            <i class="as-icon-twitter as-subheader as-m--0"></i>
-            <p class="as-toolbar__icon-text">Twitter</p>
-          </li>
-        </ul>
-      </nav>
-    </div>
-  </header>
-
-  <main class="as-app-content">
-    <div class="as-map-wrapper">
-      <div id="map"></div>
-    </div>
-  </main>
+    <main class="as-app-content">
+      <div class="as-map-wrapper">
+        <div id="map"></div>
+      </div>
+    </main>
+  </div>
 
   <script defer src="../common/map.js"></script>
   <script defer src="../common/tabs.js"></script>

--- a/examples/usage-with-carto-vl.html
+++ b/examples/usage-with-carto-vl.html
@@ -30,7 +30,7 @@
 
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <main class="as-main" style="background: #B5E0F9;">
       <div class="as-map-area">

--- a/packages/components/src/components/as-responsive-content/as-responsive-content.html
+++ b/packages/components/src/components/as-responsive-content/as-responsive-content.html
@@ -18,7 +18,7 @@
     <script src="/build/airship.js"></script>
   </head>
 
-  <body class="as-app">
+  <body class="as-app-body as-app">
     <as-responsive-content>
       <aside class="as-sidebar as-sidebar--left">
         LEFT-SIDEBAR

--- a/packages/styles/src/core/containers/test/containers-in-bottom.html
+++ b/packages/styles/src/core/containers/test/containers-in-bottom.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <main class="as-main">
       <div class="as-map-area">

--- a/packages/styles/src/core/containers/test/containers-in-legends.html
+++ b/packages/styles/src/core/containers/test/containers-in-legends.html
@@ -19,7 +19,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <main class="as-main">
       <div class="as-map-area">

--- a/packages/styles/src/core/containers/test/containers-in-sidebar-bottom-and-legends.html
+++ b/packages/styles/src/core/containers/test/containers-in-sidebar-bottom-and-legends.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <main class="as-main">
       <div class="as-map-area">

--- a/packages/styles/src/core/containers/test/containers-in-sidebar.html
+++ b/packages/styles/src/core/containers/test/containers-in-sidebar.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <main class="as-main"></main>
     <aside class="as-sidebar as-sidebar--right as-sidebar--visible">

--- a/packages/styles/src/core/layout/README.md
+++ b/packages/styles/src/core/layout/README.md
@@ -31,15 +31,17 @@ The following example contains a very basic layout with a toolbar and a sidebar.
 ```code
 lang: html
 ---
-<body class="as-app">
-  <header class="as-toolbar"></header>
-  <div class="as-content">
-    <main class="as-main">
-      <div class="as-map-area">
-        <div id="map"></div>
-      </div>
-    </main>
-    <aside class="as-sidebar as-sidebar--right"></aside>
+<body class="as-app-body">
+  <div class="as-app">
+    <header class="as-toolbar"></header>
+    <div class="as-content">
+      <main class="as-main">
+        <div class="as-map-area">
+          <div id="map"></div>
+        </div>
+      </main>
+      <aside class="as-sidebar as-sidebar--right"></aside>
+    </div>
   </div>
 </body>
 ```
@@ -54,19 +56,21 @@ The following snippet lays out:
 ```code
 lang: html
 ---
-<body class="as-app">
-  <header class="as-toolbar"></header>
-  <div class="as-content">
-    <main class="as-main">
-      <div class="as-map-area">
-        <div id="map"></div>
-      </div>
-      <footer class="as-map-footer as-bg--complementary">
-        Footer content
-      </footer>
-    </main>
+<body class="as-app-body">
+  <div class="as-app">
+    <header class="as-toolbar"></header>
+    <div class="as-content">
+      <main class="as-main">
+        <div class="as-map-area">
+          <div id="map"></div>
+        </div>
+        <footer class="as-map-footer as-bg--complementary">
+          Footer content
+        </footer>
+      </main>
 
-    <aside class="as-sidebar as-sidebar--right"></aside>
+      <aside class="as-sidebar as-sidebar--right"></aside>
+    </div>
   </div>
 </body>
 ```
@@ -82,22 +86,24 @@ The following snippet contains:
 ```code
 lang: html
 ---
-<body class="as-app">
-  <header class="as-toolbar"></header>
-  <div class="as-content">
-    <aside class="as-sidebar as-sidebar--left"></aside>
+<body class="as-app-body">
+  <div class="as-app">
+    <header class="as-toolbar"></header>
+    <div class="as-content">
+      <aside class="as-sidebar as-sidebar--left"></aside>
 
-    <main class="as-main">
-      <div class="as-map-area">
-        <div id="map"></div>
-        <div class="as-map-panels">
-          <div class="as-panel as-panel--top as-panel--right">
-            <div class="as-panel__element"></div>
+      <main class="as-main">
+        <div class="as-map-area">
+          <div id="map"></div>
+          <div class="as-map-panels">
+            <div class="as-panel as-panel--top as-panel--right">
+              <div class="as-panel__element"></div>
+            </div>
           </div>
         </div>
-      </div>
-      <footer class="as-map-footer as-bg--complementary" style="height: 100px;"></footer>
-    </main>
+        <footer class="as-map-footer as-bg--complementary" style="height: 100px;"></footer>
+      </main>
+    </div>
   </div>
 </body>
 ```

--- a/packages/styles/src/core/layout/_layout.scss
+++ b/packages/styles/src/core/layout/_layout.scss
@@ -2,12 +2,19 @@
 @import 'sidebar/_sidebar';
 @import 'toolbar/_toolbar';
 
+body.as-app-body {
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+}
+
 .as-app {
   display: flex;
   position: relative;
   flex-direction: column;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   margin: 0;
   padding: 0;
   overflow: hidden;

--- a/packages/styles/src/core/layout/main/map-area/map-panels/test/panels-mobile.html
+++ b/packages/styles/src/core/layout/main/map-area/map-panels/test/panels-mobile.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <main class="as-main">
       <div class="as-map-area">

--- a/packages/styles/src/core/layout/main/map-area/map-panels/test/panels.html
+++ b/packages/styles/src/core/layout/main/map-area/map-panels/test/panels.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <main class="as-main">
       <div class="as-map-area">

--- a/packages/styles/src/core/layout/sidebar/test/sidebar-mobile-visible.html
+++ b/packages/styles/src/core/layout/sidebar/test/sidebar-mobile-visible.html
@@ -18,7 +18,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <aside class="as-sidebar as-sidebar--left as-sidebar--visible">
       LEFT SIDEBAR

--- a/packages/styles/src/core/layout/sidebar/test/sidebar.html
+++ b/packages/styles/src/core/layout/sidebar/test/sidebar.html
@@ -18,7 +18,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-content">
     <aside class="as-sidebar as-sidebar--left as-sidebar--xl">
       LEFT SIDEBAR

--- a/packages/styles/src/core/layout/toolbar/test/tabs-with-actions-visible-left.html
+++ b/packages/styles/src/core/layout/toolbar/test/tabs-with-actions-visible-left.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 
-<body class="as-app as-app--nav-left">
+<body class="as-app-body as-app as-app--nav-left">
   <header class="as-toolbar">
     <div class="as-toolbar__group">
       <button class="as-toolbar__item as-toolbar__toggle">

--- a/packages/styles/src/core/layout/toolbar/test/tabs-with-actions-visible.html
+++ b/packages/styles/src/core/layout/toolbar/test/tabs-with-actions-visible.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <header class="as-toolbar">
     <div class="as-toolbar__group">
       <button class="as-toolbar__item as-toolbar__toggle">

--- a/packages/styles/src/core/layout/toolbar/test/tabs-with-actions.html
+++ b/packages/styles/src/core/layout/toolbar/test/tabs-with-actions.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <header class="as-toolbar">
     <button class="as-toolbar__item as-toolbar__toggle">
       <p class="as-toolbar__icon-text">Menu</p>

--- a/packages/styles/src/core/layout/toolbar/test/tabs.html
+++ b/packages/styles/src/core/layout/toolbar/test/tabs.html
@@ -17,7 +17,7 @@
   </style>
 </head>
 
-<body class="as-app">
+<body class="as-app-body as-app">
   <div class="as-toolbar-tabs as-tabs" role="tablist">
     <button role="tab" class="as-tabs__item as-tabs__item--active">MAP</button>
     <button role="tab" class="as-tabs__item">LEFT</button>


### PR DESCRIPTION
Fixes #409
---

After doing a POC using Vue to see where it's mandatory to break our cascade when using components, I've come to the conclusion that our main problem was the `as-app` selector.

In all of our examples `as-app` goes in the `body` tag and up to three nodes hang from it: `as-toolbar`, `as-tabs` and `as-content`. That causes that the main app component needs an enclosing `div` that breaks the flex cascade from body.

Splitting the old `as-app` into `as-app-body` and `as-app` allows to use `as-app` in the enclosing tag, not breaking anything. And it allows that the Airship app can be along with other content in the page.

Note: I chose `as-app-body` because `as-body` is already taken by the typography classes.

Note': changes in documentation still pending.