### PR TITLE
Revert #332

### DIFF
--- a/packages/components/src/components/as-category-widget/as-category-widget.e2e.ts
+++ b/packages/components/src/components/as-category-widget/as-category-widget.e2e.ts
@@ -105,27 +105,6 @@ describe('as-category-widget', () => {
 
       expect(categoriesSelectedSpy).toHaveReceivedEventDetail([]);
     });
-
-    it('should clear the selectedCategories when the category list is changed', async () => {
-      const element: E2EElement = await page.find('as-category-widget');
-      element.setProperty('categories', exampleCategories);
-      element.setProperty('showClearButton', true);
-
-      await page.waitForChanges();
-
-      const categoryElement = await page.find('.as-category-widget__category');
-      categoryElement.click();
-      await page.waitForChanges();
-
-      const firstResult = await element.callMethod('getSelectedCategories');
-      expect(firstResult).toEqual([exampleCategories[0].name]);
-
-      element.setProperty('categories', [{ name: 'foo', value: 10 }]);
-      await page.waitForChanges();
-
-      const secondResult = await element.callMethod('getSelectedCategories');
-      expect(secondResult).toEqual([]);
-    });
   });
 });
 

--- a/packages/components/src/components/as-category-widget/as-category-widget.tsx
+++ b/packages/components/src/components/as-category-widget/as-category-widget.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, Method, Prop, State, Watch } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Method, Prop, State } from '@stencil/core';
 import readableNumber from '../../utils/readable-number';
 import { shadeOrBlend } from '../../utils/styles';
 import { Category, CategoryOptions } from './interfaces';
@@ -134,11 +134,6 @@ export class CategoryWidget {
   @Method()
   public async getSelectedCategories() {
     return this.selectedCategories;
-  }
-
-  @Watch('categories')
-  public _watchCategories() {
-    this.clearSelection();
   }
 
   public componentWillLoad() {


### PR DESCRIPTION
This PR reverts #332 until we find a better way to handle the behaviour it tried to fix.

With that PR, any change on categories resets the selection. In CARTO.js that's the normal way of operating, changing the categories of the widget when the source changes, but the selection still makes sense. Now it's impossible to filter via widget.