### PR TITLE
Add encoding to content-type to avoid issues

### DIFF
--- a/scripts/release-s3.js
+++ b/scripts/release-s3.js
@@ -112,7 +112,7 @@ async function uploadAllFiles (dir, version, destination, subfolder='') {
       let fileContent;
       let ratio = 0;
 
-      objectConfig.ContentType = mime.getType(filePath);
+      objectConfig.ContentType = `${mime.getType(filePath)}; charset=utf-8`;
 
       try {
         fileContent = await readFile(filePath, { encoding: 'utf8' });

--- a/scripts/release-s3.js
+++ b/scripts/release-s3.js
@@ -31,6 +31,10 @@ function shouldZip (ext) {
   return true;
 }
 
+function needsUTF8 (ext) {
+  return (ext !== '.ttf' && ext !== '.woff');
+}
+
 function log (what) {
   if (!VERBOSE) {
     return;
@@ -112,10 +116,10 @@ async function uploadAllFiles (dir, version, destination, subfolder='') {
       let fileContent;
       let ratio = 0;
 
-      objectConfig.ContentType = `${mime.getType(filePath)}; charset=utf-8`;
+      objectConfig.ContentType = `${mime.getType(filePath)}${needsUTF8(extension) ? '; charset=utf-8' : ''}`;
 
       try {
-        fileContent = await readFile(filePath, { encoding: 'utf8' });
+        fileContent = await readFile(filePath, needsUTF8(extension) ? { encoding: 'utf8' } : {});
         fileLength = fileContent.length;
 
         if (shouldZip(extension)) {


### PR DESCRIPTION
#418
---

This also fixes the broken encoded characters on the banner on top of some css and js files.

Here's a release (only on s3) to test this out:

```html
<link rel="stylesheet" href="https://libs.cartocdn.com/airship-icons/testing-broken-beta/icons.css">
<link rel="stylesheet" href="https://libs.cartocdn.com/airship-style/testing-broken-beta/airship.css">
<script src="https://libs.cartocdn.com/airship-components/testing-broken-beta/airship.js"></script>
```
