### PR TITLE
Change z-index to 0

### DIFF
--- a/packages/components/src/components/as-range-slider/slider/as-range-slider.scss
+++ b/packages/components/src/components/as-range-slider/slider/as-range-slider.scss
@@ -21,7 +21,7 @@ as-range-slider {
     &::before {
       content: ' ';
       position: absolute;
-      z-index: -1;
+      z-index: 0;
       top: 50%;
       left: 0;
       width: 100%;


### PR DESCRIPTION
While using the `<as-range-slider>` component, I ran into the issue of not having the back rail bar visible. This is because the back rail bar has a z-index level of -1. I **think** it is not necessary. When using `z-index: -1`, it is set backwards by default, and therefore, it is not visible.

Example:

![screen shot 2018-10-23 at 11 23 03](https://user-images.githubusercontent.com/3824953/47350444-30727700-d6b6-11e8-9271-9155a57ac48d.png)
![screen shot 2018-10-23 at 11 25 23](https://user-images.githubusercontent.com/3824953/47350544-5f88e880-d6b6-11e8-8f95-61c2d979e098.png)
