### PR TITLE
Change publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:fix": "lerna run lint:fix",
     "lint": "lerna run lint",
     "postinstall": "lerna bootstrap --hoist",
-    "publish": "npm install && npm run build && npm run test && lerna publish && ./release.sh",
+    "publish": "npm install && npm run test && npm run build && lerna publish && ./release.sh",
     "serve": "lerna run --parallel serve",
     "showcase": "npm run build && concurrently 'serve' 'open http://localhost:5000/catalog'",
     "test:components:watch": "lerna exec --scope @carto/airship-components -- npm run test:watch",

--- a/packages/components/stencil.config.js
+++ b/packages/components/stencil.config.js
@@ -10,7 +10,6 @@ exports.config = {
     {
       type: 'www',
       serviceWorker: false,
-      empty: true,
       dir: path.join(__dirname, '../../www')
     }
   ],

--- a/packages/components/stencil.config.js
+++ b/packages/components/stencil.config.js
@@ -10,7 +10,7 @@ exports.config = {
     {
       type: 'www',
       serviceWorker: false,
-      empty: false,
+      empty: true,
       dir: path.join(__dirname, '../../www')
     }
   ],


### PR DESCRIPTION
This PR fixes the latest broken builds.

I haven't moved the uploaded folder from `www/build` to `dist` until we have a response from Ionic about the best way to do it.