### PR TITLE
Use steps when moving the range slider thumb

### DIFF
--- a/packages/components/src/components/as-range-slider/slider/as-range-slider.spec.ts
+++ b/packages/components/src/components/as-range-slider/slider/as-range-slider.spec.ts
@@ -37,6 +37,28 @@ describe('as-range-slider', () => {
       expect(onChangeSpy).toHaveBeenCalledWith([0, 1000]);
     });
 
+    it('should take steps into account', async () => {
+      rangeSlider.minValue = 0;
+      rangeSlider.maxValue = 100;
+      rangeSlider.step = 10;
+      rangeSlider.value = 20;
+
+      const onChangeSpy = jest.fn();
+      rangeSlider.change = { emit: onChangeSpy };
+
+      rangeSlider._updateThumbs(); // >> ctor ?
+      const [thumb] = rangeSlider.thumbs;
+
+      rangeSlider._onThumbMove(thumb, 27);
+      expect(onChangeSpy).lastCalledWith([30]);
+
+      rangeSlider._onThumbMove(thumb, 24);
+      expect(onChangeSpy).lastCalledWith([20]);
+
+      rangeSlider._onThumbMove(thumb, 100);
+      expect(onChangeSpy).lastCalledWith([100]);
+    });
+
     it('should emit a change event on bar move', async () => {
       rangeSlider.minValue = 0;
       rangeSlider.maxValue = 1000;

--- a/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
+++ b/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
@@ -228,7 +228,7 @@ export class RangeSlider {
     const isRightThumb = rightThumb === thumb;
 
     const value = this._getValueFromPercentage(percentage);
-    const stepValue = this._getStepValue(value);
+    const stepValue = this._getStepValueWithThreshold(value, thumb.value);
     const stepPercentage = this._getPercentage(stepValue);
 
     let valueMin = this.minValue;
@@ -306,6 +306,19 @@ export class RangeSlider {
   private _getStepValue(value) {
     const stepValue = (value / this.step) * this.step;
     return this.roundToStep(stepValue, this.step);
+  }
+
+  private _getStepValueWithThreshold(value, currentValue) {
+    const delta = value - currentValue;
+    const threshold = (this.step / 2);
+
+    if (Math.abs(delta) < threshold) {
+      return currentValue;
+    }
+
+    const sign = delta > 0 ? 1 : -1;
+
+    return this._getStepValue(currentValue + (sign * this.step));
   }
 
   private roundToStep(numberToRound: number, step: number) {

--- a/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
+++ b/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
@@ -228,7 +228,7 @@ export class RangeSlider {
     const isRightThumb = rightThumb === thumb;
 
     const value = this._getValueFromPercentage(percentage);
-    const stepValue = this._getStepValueWithThreshold(value, thumb.value);
+    const stepValue = this._getStepValue(value);
     const stepPercentage = this._getPercentage(stepValue);
 
     let valueMin = this.minValue;
@@ -304,21 +304,8 @@ export class RangeSlider {
   }
 
   private _getStepValue(value) {
-    const stepValue = (value / this.step) * this.step;
+    const stepValue = Math.round(value / this.step) * this.step;
     return this.roundToStep(stepValue, this.step);
-  }
-
-  private _getStepValueWithThreshold(value, currentValue) {
-    const delta = value - currentValue;
-    const threshold = (this.step / 2);
-
-    if (Math.abs(delta) < threshold) {
-      return currentValue;
-    }
-
-    const sign = delta > 0 ? 1 : -1;
-
-    return this._getStepValue(currentValue + (sign * this.step));
   }
 
   private roundToStep(numberToRound: number, step: number) {


### PR DESCRIPTION
Fix #429
---

It was working properly for keyboard events and moving the bar, but not for moving the thumb.