### PR TITLE
Improve s3 upload

### DIFF
--- a/scripts/spinner.js
+++ b/scripts/spinner.js
@@ -1,0 +1,35 @@
+var readline = require('readline');
+class Spinner {
+  constructor() {
+    this.characters = ['⣷', '⣯', '⣟', '⡿', '⢿', '⣻', '⣽', '⣾'];
+    this.message = null;
+    this.index = 0;
+  }
+
+  start(message) {
+    this.message = message || this.message;
+    this.index = 0;
+
+    this.timerId = setInterval(() => {
+      readline.clearLine(process.stdout, 0);
+      readline.cursorTo(process.stdout, 0);
+      process.stdout.write(` ${this.characters[this.index]} ${this.message}`);
+      readline.cursorTo(process.stdout, 0);
+    
+      this.index = this.index === this.characters.length - 1 ? 0 : this.index + 1;
+    }, 100);
+  }
+
+  stop() {
+    clearInterval(this.timerId);
+
+    readline.clearLine();
+  }
+
+  setMessage (message) {
+    this.message = message;
+  }
+
+}
+
+module.exports = Spinner;


### PR DESCRIPTION
Fix #463
---

This PR changes how we do multiple uploads to S3. If we need to upload the same file multiple times (to aliases), it uploads it once, and in case of success, copies it to the rest of paths required.

This should greatly improve the performance in cases where the bottleneck is your upload speed.

After talking with @ivanmalagon the hash / etag check won't be done right now.

I've also added a little spinner to know which file you're currently uploading :stuck_out_tongue: 

![spinner](https://user-images.githubusercontent.com/446970/48066058-d18c2200-e1cc-11e8-840a-7a357e645d66.gif)
