### PR TITLE
IE11 histogram handles

### DIFF
--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -76,17 +76,11 @@ as-histogram-widget {
     }
 
     .handle--custom {
-      width: 6px;
-      height: 28px;
       stroke-linecap: round;
       stroke: #1785FB;
       fill: white;
       cursor: ew-resize;
       pointer-events: none;
-    }
-
-    .handle--grab {
-      transform: translateY(12px);
     }
 
     .grab-line {

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -19,7 +19,7 @@ import drawService from './utils/draw.service';
 const DEFAULT_BAR_COLOR = 'var(--as--color--primary, #1785FB)';
 const DEFAULT_SELECTED_BAR_COLOR = 'var(--as--color--complementary, #47DB99)';
 const BARS_SEPARATION = 1;
-const CUSTOM_HANDLE_WIDTH = BARS_SEPARATION + 4;
+const CUSTOM_HANDLE_WIDTH = BARS_SEPARATION + 5;
 const CUSTOM_HANDLE_HEIGHT = 28;
 
 // we could use getComputedStyle instead of these
@@ -328,7 +328,7 @@ export class HistogramWidget {
 
         this.brush = brushX()
           .handleSize(CUSTOM_HANDLE_WIDTH)
-          .extent([[0, 0], [this.width - X_PADDING, this.height - Y_PADDING]])
+          .extent([[0, 0], [this.width - X_PADDING, this.height - Y_PADDING + (CUSTOM_HANDLE_HEIGHT / 2)]])
           .on('brush', this._onBrush.bind(this))
           .on('end', this._onBrushEnd.bind(this));
 
@@ -356,12 +356,15 @@ export class HistogramWidget {
         this.customHandlers
           .append('rect')
           .attr('class', 'handle--custom')
+          .attr('width', CUSTOM_HANDLE_WIDTH)
+          .attr('height', CUSTOM_HANDLE_HEIGHT)
           .attr('rx', 2)
           .attr('ry', 2);
 
         const handleGrab = this.customHandlers
           .append('g')
-          .attr('class', 'handle--grab');
+          .attr('class', 'handle--grab')
+          .attr('transform', 'translate(0, 12)');
 
 
         for (let i = 0; i < 3; i++) {

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -353,6 +353,7 @@ export class HistogramWidget {
           .append('g')
           .attr('class', 'handle--wrapper');
 
+        // We're setting width, height and transform here instead of CSS because of IE11
         this.customHandlers
           .append('rect')
           .attr('class', 'handle--custom')
@@ -363,7 +364,6 @@ export class HistogramWidget {
 
         const handleGrab = this.customHandlers
           .append('g')
-          .attr('class', 'handle--grab')
           .attr('transform', 'translate(0, 12)');
 
 

--- a/packages/styles/src/inputs/inputs.scss
+++ b/packages/styles/src/inputs/inputs.scss
@@ -22,7 +22,7 @@
   }
 
   &:hover {
-    box-shadow: inset 0 0 0 1px var(--as--color--complementary,);
+    box-shadow: inset 0 0 0 1px var(--as--color--complementary);
   }
 
   &:focus,


### PR DESCRIPTION
Fix #479 
---

Apparently IE11 doesn't like CSS + SVG very well :(

I checked Builder and we're also not setting width / height / transform on CSS.

I've also removed a typo in the CSS, it might be the reason why the docs are broken