### PR TITLE
Fix histogram colors on IE11

### DIFF
--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -76,17 +76,11 @@ as-histogram-widget {
     }
 
     .handle--custom {
-      width: 6px;
-      height: 28px;
       stroke-linecap: round;
       stroke: #1785FB;
       fill: white;
       cursor: ew-resize;
       pointer-events: none;
-    }
-
-    .handle--grab {
-      transform: translateY(12px);
     }
 
     .grab-line {

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -19,7 +19,7 @@ import drawService from './utils/draw.service';
 const DEFAULT_BAR_COLOR = 'var(--as--color--primary, #1785FB)';
 const DEFAULT_SELECTED_BAR_COLOR = 'var(--as--color--complementary, #47DB99)';
 const BARS_SEPARATION = 1;
-const CUSTOM_HANDLE_WIDTH = BARS_SEPARATION + 4;
+const CUSTOM_HANDLE_WIDTH = BARS_SEPARATION + 5;
 const CUSTOM_HANDLE_HEIGHT = 28;
 
 // we could use getComputedStyle instead of these
@@ -328,7 +328,7 @@ export class HistogramWidget {
 
         this.brush = brushX()
           .handleSize(CUSTOM_HANDLE_WIDTH)
-          .extent([[0, 0], [this.width - X_PADDING, this.height - Y_PADDING]])
+          .extent([[0, 0], [this.width - X_PADDING, this.height - Y_PADDING + (CUSTOM_HANDLE_HEIGHT / 2)]])
           .on('brush', this._onBrush.bind(this))
           .on('end', this._onBrushEnd.bind(this));
 
@@ -356,12 +356,15 @@ export class HistogramWidget {
         this.customHandlers
           .append('rect')
           .attr('class', 'handle--custom')
+          .attr('width', CUSTOM_HANDLE_WIDTH)
+          .attr('height', CUSTOM_HANDLE_HEIGHT)
           .attr('rx', 2)
           .attr('ry', 2);
 
         const handleGrab = this.customHandlers
           .append('g')
-          .attr('class', 'handle--grab');
+          .attr('class', 'handle--grab')
+          .attr('transform', 'translate(0, 12)');
 
 
         for (let i = 0; i < 3; i++) {

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, Method, Prop } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Method, Prop, Watch } from '@stencil/core';
 import { BrushBehavior, brushX } from 'd3-brush';
 import { ScaleLinear } from 'd3-scale';
 import {
@@ -193,8 +193,21 @@ export class HistogramWidget {
   private prevWidth: number;
   private prevHeight: number;
 
+  private _color: string;
+  private _selectedColor: string;
+
   constructor() {
     this._resizeRender = this._resizeRender.bind(this);
+  }
+
+  @Watch('color')
+  public _onColorChanged(newColor) {
+    this._color = this._toColor(newColor);
+  }
+
+  @Watch('selectedColor')
+  public _onSelectedColorChanged(newColor) {
+    this._selectedColor = this._toColor(newColor);
   }
 
   /**
@@ -243,6 +256,9 @@ export class HistogramWidget {
   }
 
   public componentDidLoad() {
+    this._color = this._toColor(this.color);
+    this._selectedColor = this._toColor(this.selectedColor);
+
     if (!this._hasDataToDisplay()) {
       return;
     }
@@ -395,14 +411,14 @@ export class HistogramWidget {
               clientY <= bb.bottom;
 
             if (isInsideBB) {
-              let color = selected ? this._toColor(this.selectedColor) : data.color || this._toColor(this.color);
+              let color = selected ? this._selectedColor : data.color || this._color;
               color = shadeOrBlend(-0.16, color);
               nodeSelection.style('fill', color);
               this.tooltip = this.tooltipFormatter(data);
               this._showTooltip(evt);
               anyHovered = true;
             } else {
-              nodeSelection.style('fill', selected ? this.selectedColor : data.color || this.color);
+              nodeSelection.style('fill', selected ? this._selectedColor : data.color || this._color);
             }
           });
 
@@ -416,9 +432,9 @@ export class HistogramWidget {
           this.barsContainer.selectAll('rect')
             .style('fill', (data: HistogramData) => {
               if (this._isSelected(data)) {
-                return this.selectedColor;
+                return this._selectedColor;
               }
-              return data.color || this.color;
+              return data.color || this._color;
             });
         });
 
@@ -428,7 +444,7 @@ export class HistogramWidget {
         this.container,
         this.barsContainer,
         BARS_SEPARATION,
-        this.color,
+        this._toColor(this._color),
         X_PADDING + (this.yLabel ? LABEL_PADDING : 0),
         Y_PADDING,
         resizing);
@@ -553,7 +569,7 @@ export class HistogramWidget {
       this.barsContainer.selectAll('rect')
         .style('fill', (_d, i) => {
           const d = this.data[i];
-          return d.color || this.color;
+          return d.color || this._toColor(this._color);
         });
       this.brushArea.call(this.brush.move, null);
 
@@ -582,9 +598,9 @@ export class HistogramWidget {
       .style('fill', (_d, i) => {
         const d = this.data[i];
         if ((values[0] <= d.start && d.end <= values[1])) {
-          return this.selectedColor;
+          return this._selectedColor;
         }
-        return d.color || this.color;
+        return d.color || this._color;
       });
   }
 
@@ -705,8 +721,16 @@ export class HistogramWidget {
   // If the parameter is a css variable will be evaluated to a color
   private _toColor(color) {
     if (color.startsWith('var(')) {
-      color = color.match(/--\S[^\|,)]*/)[0];
-      return getComputedStyle(this.el).getPropertyValue(color).toLowerCase().trim();
+      const match = color.match(/var\((.+),(.+)\)/);
+      const variable = match[1];
+      const fallback = match[2] || '';
+      const a = getComputedStyle(this.el).getPropertyValue(variable).toLowerCase().trim();
+
+      if (a.length === 0) {
+        return fallback.trim();
+      }
+
+      return a;
     }
     return color;
   }

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -353,6 +353,7 @@ export class HistogramWidget {
           .append('g')
           .attr('class', 'handle--wrapper');
 
+        // We're setting width, height and transform here instead of CSS because of IE11
         this.customHandlers
           .append('rect')
           .attr('class', 'handle--custom')
@@ -363,7 +364,6 @@ export class HistogramWidget {
 
         const handleGrab = this.customHandlers
           .append('g')
-          .attr('class', 'handle--grab')
           .attr('transform', 'translate(0, 12)');
 
 

--- a/packages/styles/src/inputs/inputs.scss
+++ b/packages/styles/src/inputs/inputs.scss
@@ -22,7 +22,7 @@
   }
 
   &:hover {
-    box-shadow: inset 0 0 0 1px var(--as--color--complementary,);
+    box-shadow: inset 0 0 0 1px var(--as--color--complementary);
   }
 
   &:focus,


### PR DESCRIPTION
Fix #480
---

We were trying to use getComputedStyle to get the variable color, but that's not possible on IE, so I'm parsing the var and getting the fallback color from it if getComputedStyle doesn't return anything helpful.