### PR TITLE
IE11 Stacked Bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,11 +19,11 @@
   <div class="as-content">
     <main class="as-main as-p--40">
       <h1 class="as-jumbo">Airship</h1>
-      <a class="as-title" href="http://localhost:5000/catalog/#/">Catalog</a>
-      <a class="as-title" href="http://localhost:5000/examples">Examples</a>
-      <a class="as-title" href="http://localhost:5000/packages/components/src/components/">Components</a>
-      <a class="as-title" href="http://localhost:5000/packages/styles/src/">Styles</a>
-      <a class="as-title" href="http://localhost:5000/packages/smoke/">Smoke Tests</a>
+      <a class="as-title" href="catalog/#/">Catalog</a>
+      <a class="as-title" href="examples">Examples</a>
+      <a class="as-title" href="packages/components/src/components/">Components</a>
+      <a class="as-title" href="packages/styles/src/">Styles</a>
+      <a class="as-title" href="packages/smoke/">Smoke Tests</a>
     </main>
   </div>
 </body>

--- a/packages/components/src/components/as-stacked-bar-widget/utils/data.service.ts
+++ b/packages/components/src/components/as-stacked-bar-widget/utils/data.service.ts
@@ -67,7 +67,9 @@ export function getKeys(data: RawStackedbarData[]): string[] {
       keys.add(key);
     });
   }
-  return Array.from(keys);
+  const result = [];
+  keys.forEach((key) => result.push(key));
+  return result;
 }
 
 export function createLegendData(metadata: Metadata, colorMap: ColorMap) {

--- a/packages/components/src/utils/readable-number.ts
+++ b/packages/components/src/utils/readable-number.ts
@@ -1,3 +1,60 @@
+if (!String.prototype.repeat) {
+  String.prototype.repeat = function(count) {
+    'use strict';
+    if (this == null) {
+      throw new TypeError('can\'t convert ' + this + ' to object');
+    }
+    let str = '' + this;
+    count = +count;
+    if (count !== count) {
+      count = 0;
+    }
+    if (count < 0) {
+      throw new RangeError('repeat count must be non-negative');
+    }
+    if (count === Infinity) {
+      throw new RangeError('repeat count must be less than infinity');
+    }
+    count = Math.floor(count);
+    if (str.length === 0 || count === 0) {
+      return '';
+    }
+    // Ensuring count is a 31-bit integer allows us to heavily optimize the
+    // main part. But anyway, most current (August 2014) browsers can't handle
+    // strings 1 << 28 chars or longer, so:
+    // tslint:disable-next-line:no-bitwise
+    if (str.length * count >= 1 << 28) {
+      throw new RangeError('repeat count must not overflow maximum string size');
+    }
+    const maxCount = str.length * count;
+    count = Math.floor(Math.log(count) / Math.log(2));
+    while (count) {
+       str += str;
+       count--;
+    }
+    str += str.substring(0, maxCount - str.length);
+    return str;
+  };
+}
+
+if (!String.prototype.padStart) {
+  String.prototype.padStart = function padStart(targetLength, padString) {
+      // tslint:disable-next-line:no-bitwise
+      targetLength = targetLength >> 0; // truncate if number, or convert non-number to 0;
+      padString = String(typeof padString !== 'undefined' ? padString : ' ');
+      if (this.length >= targetLength) {
+          return String(this);
+      } else {
+          targetLength = targetLength - this.length;
+          if (targetLength > padString.length) {
+              // append to original to ensure we are longer than needed
+              padString += padString.repeat(targetLength / padString.length);
+          }
+          return padString.slice(0, targetLength) + String(this);
+      }
+  };
+}
+
 /**
  *  Convert long numbers to
  *  readizable numbers.

--- a/packages/components/src/utils/readable-number.ts
+++ b/packages/components/src/utils/readable-number.ts
@@ -74,5 +74,10 @@ export default function(value): string {
     return `${(roundedNumber / 1000).toFixed(1)}K`.padStart(5);
   }
 
-  return `${roundedNumber}`.padStart(5);
+  const roundedStr = `${roundedNumber}`;
+
+  // This seems backwards but it's an IE11 issue.
+  // padStart(5) looks weird for 0 - 9, looks better with padStart(7)
+  // 10 - 99 looks better with padStart(6)
+  return roundedStr.padStart(5 + Math.abs(roundedStr.length - 3));
 }


### PR DESCRIPTION
Fix #478 
---

This adds two polyfills we need (String.padStart, and String.repeat for String.padStart), and removes a call to Array.from.

I don't know if Array.from supports calls with a Set, but I checked and Stencil's polyfill always returns an empty array. The one on MDN as well, so I'm guessing no? So I replaced it with a forEach 🤷‍♂️ 