### PR TITLE
Fix IE11 sidebar problems

### DIFF
--- a/packages/smoke/cdn/smoke_0.html
+++ b/packages/smoke/cdn/smoke_0.html
@@ -21,6 +21,10 @@
       right: 30px;
     }
 
+    .as-map-area {
+      background-color: #DEBFCD;
+    }
+
   </style>
 </head>
 
@@ -30,8 +34,16 @@
     <div class="as-toolbar__item">
       <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzJweCIgaGVpZ2h0PSIzMnB4IiB2aWV3Qm94PSI3NjIgLTU4IDMyIDMyIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogIDxnIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDc2Mi4wMDAwMDAsIC01OC4wMDAwMDApIj4KICAgIDxjaXJjbGUgY2xhc3M9IkhhbG8iIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuMiIgY3g9IjE2IiBjeT0iMTYiIHI9IjE2Ij48L2NpcmNsZT4KICAgIDxjaXJjbGUgY2xhc3M9InBvaW50IiBmaWxsPSIjRkZGRkZGIiBjeD0iMTYiIGN5PSIxNiIgcj0iNS41Ij48L2NpcmNsZT4KICA8L2c+Cjwvc3ZnPgo=" alt="Logo" />
     </div>
-    <a href="#" class="as-toolbar__item">Link</a>
-    <p class="as-toolbar__item">Paragraph</p>
+    <nav class="as-toolbar__actions">
+      <ul>
+        <li>
+          <a href="#" class="as-toolbar__item">Link</a>
+        </li>
+        <li>
+          <a href="#" class="as-toolbar__item">Paragraph</a>
+        </li>
+      </ul>
+    </nav>
     <i class="as-toolbar__item as-icon-points"></i>
   </as-toolbar>
 
@@ -58,28 +70,6 @@
           <div class="as-p--12" role="tabpanel" data-title="Dropdown">
             <h1 class="as-title">Dropdown</h1>
             <as-dropdown default-text="Dropdown" can-clear="true"></as-dropdown>
-
-            <script>
-              const dropdown = document.querySelector('as-dropdown');
-              dropdown.options = [{
-                  text: 'All',
-                  value: 'all'
-                },
-                {
-                  text: 'Open',
-                  value: 'open'
-                },
-                {
-                  text: 'Unfulfilled',
-                  value: 'unfulfilled'
-                },
-                {
-                  text: 'Unpaid',
-                  value: 'unpaid'
-                }
-              ];
-
-            </script>
           </div>
         </as-tabs>
       </div>
@@ -180,47 +170,71 @@
     <aside class="as-sidebar as-sidebar--right">
       <div class="as-container">
         <as-category-widget class="as-p--16" heading="Business Volume" description="Description" default-bar-color="#47DB99"></as-category-widget>
-        <script>
-          const categoryWidget = document.querySelector('as-category-widget');
-          categoryWidget.showHeader = true;
-          categoryWidget.showClearButton = true;
-          categoryWidget.useTotalPercentage = false;
-          categoryWidget.visibleCategories = Infinity;
-          categoryWidget.categories = [{
-              name: 'Bars & Restaurants',
-              value: 1000,
-              color: '#FABADA'
-            },
-            {
-              name: 'Fashion',
-              value: 900
-            },
-            {
-              name: 'Grocery',
-              value: 800
-            },
-            {
-              name: 'Health',
-              value: 400
-            },
-            {
-              name: 'Shopping mall',
-              value: 250
-            },
-            {
-              name: 'Transportation',
-              value: 1000
-            },
-            {
-              name: 'Leisure',
-              value: 760
-            }
-          ];
-
-        </script>
       </div>
     </aside>
   </as-responsive-content>
+
+  <script>
+    function onReady () {
+      const dropdown = document.querySelector('as-dropdown');
+      dropdown.options = [{
+          text: 'All',
+          value: 'all'
+        },
+        {
+          text: 'Open',
+          value: 'open'
+        },
+        {
+          text: 'Unfulfilled',
+          value: 'unfulfilled'
+        },
+        {
+          text: 'Unpaid',
+          value: 'unpaid'
+        }
+      ];
+
+      const categoryWidget = document.querySelector('as-category-widget');
+      categoryWidget.showHeader = true;
+      categoryWidget.showClearButton = true;
+      categoryWidget.useTotalPercentage = false;
+      categoryWidget.visibleCategories = Infinity;
+      categoryWidget.categories = [{
+          name: 'Bars & Restaurants',
+          value: 1000,
+          color: '#FABADA'
+        },
+        {
+          name: 'Fashion',
+          value: 900
+        },
+        {
+          name: 'Grocery',
+          value: 800
+        },
+        {
+          name: 'Health',
+          value: 400
+        },
+        {
+          name: 'Shopping mall',
+          value: 250
+        },
+        {
+          name: 'Transportation',
+          value: 1000
+        },
+        {
+          name: 'Leisure',
+          value: 760
+        }
+      ];
+    }
+
+    var responsiveContent = document.querySelector('as-responsive-content');
+    responsiveContent.addEventListener('ready', onReady);
+  </script>
 </body>
 
 </html>

--- a/packages/smoke/current/smoke_0.html
+++ b/packages/smoke/current/smoke_0.html
@@ -113,14 +113,13 @@
           </p>
         </as-infowindow>
 
-
       </div>
       <footer class="as-map-footer as-bg--complementary">
         <div class="as-container">
-          <as-stacked-bar-widget id="widget-0" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
+          <as-stacked-bar-widget id="stackedFooter" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
         </div>
         <div class="as-container">
-          <as-histogram-widget heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
         </div>
       </footer>
     </main>
@@ -128,17 +127,14 @@
     <aside class="as-sidebar as-sidebar--right">
       <div class="as-container">
         <as-category-widget class="as-p--16" heading="Business Volume" description="Description" default-bar-color="#47DB99"></as-category-widget>
-        <script>
-
-
-        </script>
+        <as-stacked-bar-widget id="stackedSidebar" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
+        <as-histogram-widget id="histogramSidebar" class="as-p--16" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
       </div>
     </aside>
   </as-responsive-content>
   <script>
     function onReady () {
-      const widget0 = document.querySelector('as-stacked-bar-widget');
-      widget0.data = [{
+      var stackedData = [{
           category: 'Star Wars Ep. IV: A New Hope',
           values: {
             dvd: 27229125,
@@ -161,7 +157,7 @@
         }
       ];
 
-      widget0.metadata = {
+      var stackedMetadata = {
         dvd: {
           label: 'Domestic DVD Sales',
           color: '#33ACEE'
@@ -172,8 +168,14 @@
         }
       }
 
-      var histogramWidget = document.querySelector('as-histogram-widget');
-      histogramWidget.data = [{
+      const stackedFooter = document.getElementById('stackedFooter');
+      const stackedSidebar = document.getElementById('stackedSidebar');
+      stackedFooter.data = stackedData;
+      stackedFooter.metadata = stackedMetadata;
+      stackedSidebar.data = stackedData;
+      stackedSidebar.metadata = stackedMetadata;
+
+      var histogramData =  [{
           start: 0,
           end: 10,
           value: 5
@@ -199,6 +201,11 @@
           value: 30
         },
       ];
+
+      var histogramFooter = document.getElementById('histogramFooter');
+      var histogramSidebar = document.getElementById('histogramSidebar');
+      histogramFooter.data = histogramData;
+      histogramSidebar.data = histogramData;
 
       const categoryWidget = document.querySelector('as-category-widget');
       categoryWidget.showHeader = true;

--- a/packages/smoke/current/smoke_0.html
+++ b/packages/smoke/current/smoke_0.html
@@ -21,6 +21,10 @@
       right: 30px;
     }
 
+    .as-map-area {
+      background-color: #DEBFCD;
+    }
+
   </style>
 </head>
 
@@ -31,8 +35,16 @@
       <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzJweCIgaGVpZ2h0PSIzMnB4IiB2aWV3Qm94PSI3NjIgLTU4IDMyIDMyIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogIDxnIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDc2Mi4wMDAwMDAsIC01OC4wMDAwMDApIj4KICAgIDxjaXJjbGUgY2xhc3M9IkhhbG8iIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuMiIgY3g9IjE2IiBjeT0iMTYiIHI9IjE2Ij48L2NpcmNsZT4KICAgIDxjaXJjbGUgY2xhc3M9InBvaW50IiBmaWxsPSIjRkZGRkZGIiBjeD0iMTYiIGN5PSIxNiIgcj0iNS41Ij48L2NpcmNsZT4KICA8L2c+Cjwvc3ZnPgo="
         alt="Logo" />
     </div>
-    <a href="#" class="as-toolbar__item">Link</a>
-    <p class="as-toolbar__item">Paragraph</p>
+    <nav class="as-toolbar__actions">
+      <ul>
+        <li>
+          <a href="#" class="as-toolbar__item">Link</a>
+        </li>
+        <li>
+          <a href="#" class="as-toolbar__item">Paragraph</a>
+        </li>
+      </ul>
+    </nav>
     <i class="as-toolbar__item as-icon-points"></i>
   </as-toolbar>
 
@@ -110,71 +122,6 @@
         <div class="as-container">
           <as-histogram-widget heading="Title" description="Description" show-header show-clear></as-histogram-widget>
         </div>
-        <script>
-          const widget0 = document.querySelector('as-stacked-bar-widget');
-          widget0.data = [{
-              category: 'Star Wars Ep. IV: A New Hope',
-              values: {
-                dvd: 27229125,
-                blue: 3555058,
-              }
-            },
-            {
-              category: 'Star Wars Ep. V: The Empire Strikes Back',
-              values: {
-                dvd: 24928640,
-                blue: 2738207,
-              },
-            },
-            {
-              category: 'Star Wars Ep. VI: Return of the Jedi',
-              values: {
-                dvd: 23786454,
-                blue: 1908593,
-              }
-            }
-          ];
-
-          widget0.metadata = {
-            dvd: {
-              label: 'Domestic DVD Sales',
-              color: '#33ACEE'
-            },
-            blue: {
-              label: 'Domestic Blu-ray Sales',
-              color: '#EEC649'
-            }
-          }
-
-          var histogramWidget = document.querySelector('as-histogram-widget');
-          histogramWidget.data = [{
-              start: 0,
-              end: 10,
-              value: 5
-            },
-            {
-              start: 10,
-              end: 20,
-              value: 10
-            },
-            {
-              start: 20,
-              end: 30,
-              value: 15
-            },
-            {
-              start: 30,
-              end: 40,
-              value: 20
-            },
-            {
-              start: 40,
-              end: 50,
-              value: 30
-            },
-          ];
-
-        </script>
       </footer>
     </main>
 
@@ -182,46 +129,117 @@
       <div class="as-container">
         <as-category-widget class="as-p--16" heading="Business Volume" description="Description" default-bar-color="#47DB99"></as-category-widget>
         <script>
-          const categoryWidget = document.querySelector('as-category-widget');
-          categoryWidget.showHeader = true;
-          categoryWidget.showClearButton = true;
-          categoryWidget.useTotalPercentage = false;
-          categoryWidget.visibleCategories = Infinity;
-          categoryWidget.categories = [{
-              name: 'Bars & Restaurants',
-              value: 1000,
-              color: '#FABADA'
-            },
-            {
-              name: 'Fashion',
-              value: 900
-            },
-            {
-              name: 'Grocery',
-              value: 800
-            },
-            {
-              name: 'Health',
-              value: 400
-            },
-            {
-              name: 'Shopping mall',
-              value: 250
-            },
-            {
-              name: 'Transportation',
-              value: 1000
-            },
-            {
-              name: 'Leisure',
-              value: 760
-            }
-          ];
+
 
         </script>
       </div>
     </aside>
   </as-responsive-content>
+  <script>
+    function onReady () {
+      const widget0 = document.querySelector('as-stacked-bar-widget');
+      widget0.data = [{
+          category: 'Star Wars Ep. IV: A New Hope',
+          values: {
+            dvd: 27229125,
+            blue: 3555058,
+          }
+        },
+        {
+          category: 'Star Wars Ep. V: The Empire Strikes Back',
+          values: {
+            dvd: 24928640,
+            blue: 2738207,
+          },
+        },
+        {
+          category: 'Star Wars Ep. VI: Return of the Jedi',
+          values: {
+            dvd: 23786454,
+            blue: 1908593,
+          }
+        }
+      ];
+
+      widget0.metadata = {
+        dvd: {
+          label: 'Domestic DVD Sales',
+          color: '#33ACEE'
+        },
+        blue: {
+          label: 'Domestic Blu-ray Sales',
+          color: '#EEC649'
+        }
+      }
+
+      var histogramWidget = document.querySelector('as-histogram-widget');
+      histogramWidget.data = [{
+          start: 0,
+          end: 10,
+          value: 5
+        },
+        {
+          start: 10,
+          end: 20,
+          value: 10
+        },
+        {
+          start: 20,
+          end: 30,
+          value: 15
+        },
+        {
+          start: 30,
+          end: 40,
+          value: 20
+        },
+        {
+          start: 40,
+          end: 50,
+          value: 30
+        },
+      ];
+
+      const categoryWidget = document.querySelector('as-category-widget');
+      categoryWidget.showHeader = true;
+      categoryWidget.showClearButton = true;
+      categoryWidget.useTotalPercentage = false;
+      categoryWidget.visibleCategories = Infinity;
+      categoryWidget.categories = [{
+          name: 'Bars & Restaurants',
+          value: 1000,
+          color: '#FABADA'
+        },
+        {
+          name: 'Fashion',
+          value: 900
+        },
+        {
+          name: 'Grocery',
+          value: 800
+        },
+        {
+          name: 'Health',
+          value: 400
+        },
+        {
+          name: 'Shopping mall',
+          value: 250
+        },
+        {
+          name: 'Transportation',
+          value: 1000
+        },
+        {
+          name: 'Leisure',
+          value: 760
+        }
+      ];
+    }
+
+    var responsiveContent = document.querySelector('as-responsive-content');
+    responsiveContent.addEventListener('ready', onReady);
+  </script>
 </body>
 
 </html>

--- a/packages/smoke/npm/smoke_0.html
+++ b/packages/smoke/npm/smoke_0.html
@@ -19,6 +19,10 @@
       right: 30px;
     }
 
+    .as-map-area {
+      background-color: #DEBFCD;
+    }
+
   </style>
 </head>
 
@@ -29,8 +33,16 @@
       <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzJweCIgaGVpZ2h0PSIzMnB4IiB2aWV3Qm94PSI3NjIgLTU4IDMyIDMyIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogIDxnIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDc2Mi4wMDAwMDAsIC01OC4wMDAwMDApIj4KICAgIDxjaXJjbGUgY2xhc3M9IkhhbG8iIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuMiIgY3g9IjE2IiBjeT0iMTYiIHI9IjE2Ij48L2NpcmNsZT4KICAgIDxjaXJjbGUgY2xhc3M9InBvaW50IiBmaWxsPSIjRkZGRkZGIiBjeD0iMTYiIGN5PSIxNiIgcj0iNS41Ij48L2NpcmNsZT4KICA8L2c+Cjwvc3ZnPgo="
         alt="Logo" />
     </div>
-    <a href="#" class="as-toolbar__item">Link</a>
-    <p class="as-toolbar__item">Paragraph</p>
+    <nav class="as-toolbar__actions">
+      <ul>
+        <li>
+          <a href="#" class="as-toolbar__item">Link</a>
+        </li>
+        <li>
+          <a href="#" class="as-toolbar__item">Paragraph</a>
+        </li>
+      </ul>
+    </nav>
     <i class="as-toolbar__item as-icon-points"></i>
   </as-toolbar>
 
@@ -51,34 +63,11 @@
               rangeSliderWidget.maxValue = 20;
               rangeSliderWidget.value = 12;
               rangeSliderWidget.step = 2;
-
             </script>
           </div>
           <div class="as-p--12" role="tabpanel" data-title="Dropdown">
             <h1 class="as-title">Dropdown</h1>
             <as-dropdown default-text="Dropdown" can-clear="true"></as-dropdown>
-
-            <script>
-              const dropdown = document.querySelector('as-dropdown');
-              dropdown.options = [{
-                  text: 'All',
-                  value: 'all'
-                },
-                {
-                  text: 'Open',
-                  value: 'open'
-                },
-                {
-                  text: 'Unfulfilled',
-                  value: 'unfulfilled'
-                },
-                {
-                  text: 'Unpaid',
-                  value: 'unpaid'
-                }
-              ];
-
-            </script>
           </div>
         </as-tabs>
       </div>
@@ -108,118 +97,139 @@
         <div class="as-container">
           <as-histogram-widget heading="Title" description="Description" show-header show-clear></as-histogram-widget>
         </div>
-        <script>
-          const widget0 = document.querySelector('as-stacked-bar-widget');
-          widget0.data = [{
-              category: 'Star Wars Ep. IV: A New Hope',
-              values: {
-                dvd: 27229125,
-                blue: 3555058,
-              }
-            },
-            {
-              category: 'Star Wars Ep. V: The Empire Strikes Back',
-              values: {
-                dvd: 24928640,
-                blue: 2738207,
-              },
-            },
-            {
-              category: 'Star Wars Ep. VI: Return of the Jedi',
-              values: {
-                dvd: 23786454,
-                blue: 1908593,
-              }
-            }
-          ];
-
-          widget0.metadata = {
-            dvd: {
-              label: 'Domestic DVD Sales',
-              color: '#33ACEE'
-            },
-            blue: {
-              label: 'Domestic Blu-ray Sales',
-              color: '#EEC649'
-            }
-          }
-
-          var histogramWidget = document.querySelector('as-histogram-widget');
-          histogramWidget.data = [{
-              start: 0,
-              end: 10,
-              value: 5
-            },
-            {
-              start: 10,
-              end: 20,
-              value: 10
-            },
-            {
-              start: 20,
-              end: 30,
-              value: 15
-            },
-            {
-              start: 30,
-              end: 40,
-              value: 20
-            },
-            {
-              start: 40,
-              end: 50,
-              value: 30
-            },
-          ];
-
-        </script>
       </footer>
     </main>
 
     <aside class="as-sidebar as-sidebar--right">
       <div class="as-container">
         <as-category-widget class="as-p--16" heading="Business Volume" description="Description" default-bar-color="#47DB99"></as-category-widget>
-        <script>
-          const categoryWidget = document.querySelector('as-category-widget');
-          categoryWidget.showHeader = true;
-          categoryWidget.showClearButton = true;
-          categoryWidget.useTotalPercentage = false;
-          categoryWidget.visibleCategories = Infinity;
-          categoryWidget.categories = [{
-              name: 'Bars & Restaurants',
-              value: 1000,
-              color: '#FABADA'
-            },
-            {
-              name: 'Fashion',
-              value: 900
-            },
-            {
-              name: 'Grocery',
-              value: 800
-            },
-            {
-              name: 'Health',
-              value: 400
-            },
-            {
-              name: 'Shopping mall',
-              value: 250
-            },
-            {
-              name: 'Transportation',
-              value: 1000
-            },
-            {
-              name: 'Leisure',
-              value: 760
-            }
-          ];
-
-        </script>
       </div>
     </aside>
   </as-responsive-content>
+  <script>
+    function onReady () {
+      const dropdown = document.querySelector('as-dropdown');
+      dropdown.options = [{
+          text: 'All',
+          value: 'all'
+        },
+        {
+          text: 'Open',
+          value: 'open'
+        },
+        {
+          text: 'Unfulfilled',
+          value: 'unfulfilled'
+        },
+        {
+          text: 'Unpaid',
+          value: 'unpaid'
+        }
+      ];
+
+      const widget0 = document.querySelector('as-stacked-bar-widget');
+      widget0.data = [{
+          category: 'Star Wars Ep. IV: A New Hope',
+          values: {
+            dvd: 27229125,
+            blue: 3555058,
+          }
+        },
+        {
+          category: 'Star Wars Ep. V: The Empire Strikes Back',
+          values: {
+            dvd: 24928640,
+            blue: 2738207,
+          },
+        },
+        {
+          category: 'Star Wars Ep. VI: Return of the Jedi',
+          values: {
+            dvd: 23786454,
+            blue: 1908593,
+          }
+        }
+      ];
+
+      widget0.metadata = {
+        dvd: {
+          label: 'Domestic DVD Sales',
+          color: '#33ACEE'
+        },
+        blue: {
+          label: 'Domestic Blu-ray Sales',
+          color: '#EEC649'
+        }
+      }
+
+      var histogramWidget = document.querySelector('as-histogram-widget');
+      histogramWidget.data = [{
+          start: 0,
+          end: 10,
+          value: 5
+        },
+        {
+          start: 10,
+          end: 20,
+          value: 10
+        },
+        {
+          start: 20,
+          end: 30,
+          value: 15
+        },
+        {
+          start: 30,
+          end: 40,
+          value: 20
+        },
+        {
+          start: 40,
+          end: 50,
+          value: 30
+        },
+      ];
+
+      const categoryWidget = document.querySelector('as-category-widget');
+      categoryWidget.showHeader = true;
+      categoryWidget.showClearButton = true;
+      categoryWidget.useTotalPercentage = false;
+      categoryWidget.visibleCategories = Infinity;
+      categoryWidget.categories = [{
+          name: 'Bars & Restaurants',
+          value: 1000,
+          color: '#FABADA'
+        },
+        {
+          name: 'Fashion',
+          value: 900
+        },
+        {
+          name: 'Grocery',
+          value: 800
+        },
+        {
+          name: 'Health',
+          value: 400
+        },
+        {
+          name: 'Shopping mall',
+          value: 250
+        },
+        {
+          name: 'Transportation',
+          value: 1000
+        },
+        {
+          name: 'Leisure',
+          value: 760
+        }
+      ];
+    }
+
+    var responsiveContent = document.querySelector('as-responsive-content');
+    responsiveContent.addEventListener('ready', onReady);
+  </script>
 </body>
 
 </html>

--- a/packages/styles/src/core/layout/main/map-area/map-panels/_map-panels.scss
+++ b/packages/styles/src/core/layout/main/map-area/map-panels/_map-panels.scss
@@ -19,7 +19,7 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    overflow-y: initial;
+    overflow-y: visible;
     background-color: initial;
     pointer-events: none;
   }

--- a/packages/styles/src/core/layout/main/map-footer/_map-footer.scss
+++ b/packages/styles/src/core/layout/main/map-footer/_map-footer.scss
@@ -9,7 +9,7 @@
   pointer-events: auto;
 
   &--visible {
-    display: initial;
+    display: inline;
     z-index: 4;
     overflow-x: auto;
   }
@@ -17,8 +17,7 @@
   // Media
   @media all and (min-width: $tablet-breakpoint) {
     display: flex;
-    position: initial;
-    height: initial;
+    position: static;
     max-height: $bottom-bar-max-height;
     overflow-x: auto;
 

--- a/packages/styles/src/core/layout/sidebar/_sidebar.scss
+++ b/packages/styles/src/core/layout/sidebar/_sidebar.scss
@@ -44,7 +44,7 @@
   // Media
   @media all and (min-width: $tablet-breakpoint) {
     display: flex;
-    position: initial;
+    position: static;
     top: 0;
     flex: 0 0 auto;
     width: 260px;

--- a/packages/styles/src/core/layout/toolbar/_actions.scss
+++ b/packages/styles/src/core/layout/toolbar/_actions.scss
@@ -33,7 +33,7 @@
 
   // Media queries
   @media all and (min-width: $tablet-breakpoint) {
-    position: initial;
+    position: static;
     top: 0;
     left: 0;
     flex-direction: row;


### PR DESCRIPTION
Fixes IE11 sidebar problems from #489

The problem was that `initial` is a value not understood by IE11 at all. I've substituted the ones that caused the problems for their actual value.

There's also a refactor on smoke templates:
- Map area has a background color to check what it's rendering in a given time.
- There's a nav bar with toolbar actions to check the burguer menu.
- Widget feeding is done after `as-responsive-content` `ready` event.

PS: the name of the branch is not well named.