### PR TITLE
Remove height style within widgets

### DIFF
--- a/packages/components/src/components/as-category-widget/as-category-widget.scss
+++ b/packages/components/src/components/as-category-widget/as-category-widget.scss
@@ -10,6 +10,8 @@ as-category-widget {
   --category-bar--color: var(--as--color--complementary);
 
   display: block;
+  min-width: 260px;
+  overflow-y: auto;
   background: var(--category-widget--background-color, $color-ui-01);
 
   .content {

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -8,6 +8,7 @@ as-histogram-widget {
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-width: 260px;
   height: 100%;
   max-height: 100%;
   overflow: auto;

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -8,7 +8,6 @@ as-histogram-widget {
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
   max-height: 100%;
   overflow: auto;
   background: var(--as-histogram-widget--background-color, #FFF);

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -8,6 +8,7 @@ as-histogram-widget {
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100%;
   max-height: 100%;
   overflow: auto;
   background: var(--as-histogram-widget--background-color, #FFF);

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -17,6 +17,9 @@ as-histogram-widget {
     display: flex;
     position: relative;
     flex: 1;
+
+    /* https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox */
+    min-height: 0;
   }
 
   .as-histogram-widget__clear {

--- a/packages/components/src/components/as-responsive-content/as-responsive-content.scss
+++ b/packages/components/src/components/as-responsive-content/as-responsive-content.scss
@@ -4,4 +4,7 @@ as-responsive-content {
   display: flex;
   flex: 1;
   flex-direction: column;
+
+  /* https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox */
+  min-height: 0;
 }

--- a/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.scss
+++ b/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.scss
@@ -7,6 +7,7 @@ as-stacked-bar-widget {
   display: flex;
   flex-direction: column;
   width: 100%;
+  min-width: 260px;
   height: 100%;
   max-height: 100%;
   overflow: auto;

--- a/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.scss
+++ b/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.scss
@@ -7,6 +7,7 @@ as-stacked-bar-widget {
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100%;
   max-height: 100%;
   overflow: auto;
   background: var(--stacked-bar-widget--background-color, #FFF);

--- a/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.scss
+++ b/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.scss
@@ -7,7 +7,6 @@ as-stacked-bar-widget {
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
   max-height: 100%;
   overflow: auto;
   background: var(--stacked-bar-widget--background-color, #FFF);

--- a/packages/smoke/current/ffox_layout.html
+++ b/packages/smoke/current/ffox_layout.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Firefox Layout</title>
+  <link rel="stylesheet" href="/packages/styles/dist/airship.css">
+  <link rel="stylesheet" href="/packages/icons/dist/icons.css">
+  <script src="/packages/components/dist/airship.js"></script>
+  <style>
+    .as-map-area {
+      background-color: #DEBFCD;
+    }
+
+  </style>
+</head>
+
+<body class="as-app-body as-app">
+
+  <as-toolbar>
+    <div class="as-toolbar__item">
+      <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzJweCIgaGVpZ2h0PSIzMnB4IiB2aWV3Qm94PSI3NjIgLTU4IDMyIDMyIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogIDxnIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDc2Mi4wMDAwMDAsIC01OC4wMDAwMDApIj4KICAgIDxjaXJjbGUgY2xhc3M9IkhhbG8iIGZpbGw9IiNGRkZGRkYiIG9wYWNpdHk9IjAuMiIgY3g9IjE2IiBjeT0iMTYiIHI9IjE2Ij48L2NpcmNsZT4KICAgIDxjaXJjbGUgY2xhc3M9InBvaW50IiBmaWxsPSIjRkZGRkZGIiBjeD0iMTYiIGN5PSIxNiIgcj0iNS41Ij48L2NpcmNsZT4KICA8L2c+Cjwvc3ZnPgo="
+        alt="Logo" />
+    </div>
+    <nav class="as-toolbar__actions">
+      <ul>
+        <li>
+          <a href="#" class="as-toolbar__item">Link</a>
+        </li>
+        <li>
+          <a href="#" class="as-toolbar__item">Paragraph</a>
+        </li>
+      </ul>
+    </nav>
+    <i class="as-toolbar__item as-icon-points"></i>
+  </as-toolbar>
+
+  <section class="as-content">
+    <aside class="as-sidebar as-sidebar--left">
+    </aside>
+
+    <main class="as-main">
+      <div class="as-map-area">
+        <div id="map"></div>
+      </div>
+      <footer class="as-map-footer as-bg--complementary">
+        <as-stacked-bar-widget id="stackedFooter" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
+        <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+      </footer>
+    </main>
+
+    <aside class="as-sidebar as-sidebar--right">
+      <div>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+        <p>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Error dolore aliquid veniam aut explicabo, magni
+          corporis recusandae voluptas, quia vitae aliquam quis corrupti eaque! Temporibus ut quidem possimus nihil
+          nulla.m
+        </p>
+      </div>
+    </aside>
+  </section>
+  <script>
+    function onReady() {
+      var stackedData = [{
+          category: 'Star Wars Ep. IV: A New Hope',
+          values: {
+            dvd: 27229125,
+            blue: 3555058,
+          }
+        },
+        {
+          category: 'Star Wars Ep. V: The Empire Strikes Back',
+          values: {
+            dvd: 24928640,
+            blue: 2738207,
+          },
+        },
+        {
+          category: 'Star Wars Ep. VI: Return of the Jedi',
+          values: {
+            dvd: 23786454,
+            blue: 1908593,
+          }
+        }
+      ];
+
+      var stackedMetadata = {
+        dvd: {
+          label: 'Domestic DVD Sales',
+          color: '#33ACEE'
+        },
+        blue: {
+          label: 'Domestic Blu-ray Sales',
+          color: '#EEC649'
+        }
+      }
+
+      const stackedFooter = document.getElementById('stackedFooter');
+      const stackedSidebar = document.getElementById('stackedSidebar');
+      stackedFooter.data = stackedData;
+      stackedFooter.metadata = stackedMetadata;
+      stackedSidebar.data = stackedData;
+      stackedSidebar.metadata = stackedMetadata;
+
+      var histogramData = [{
+          start: 0,
+          end: 10,
+          value: 5
+        },
+        {
+          start: 10,
+          end: 20,
+          value: 10
+        },
+        {
+          start: 20,
+          end: 30,
+          value: 15
+        },
+        {
+          start: 30,
+          end: 40,
+          value: 20
+        },
+        {
+          start: 40,
+          end: 50,
+          value: 30
+        },
+      ];
+
+      var histogramFooter = document.getElementById('histogramFooter');
+      var histogramSidebar = document.getElementById('histogramSidebar');
+      histogramFooter.data = histogramData;
+      histogramSidebar.data = histogramData;
+
+      const categoryWidget = document.querySelector('as-category-widget');
+      categoryWidget.showHeader = true;
+      categoryWidget.showClearButton = true;
+      categoryWidget.useTotalPercentage = false;
+      categoryWidget.visibleCategories = Infinity;
+      categoryWidget.categories = [{
+          name: 'Bars & Restaurants',
+          value: 1000,
+          color: '#FABADA'
+        },
+        {
+          name: 'Fashion',
+          value: 900
+        },
+        {
+          name: 'Grocery',
+          value: 800
+        },
+        {
+          name: 'Health',
+          value: 400
+        },
+        {
+          name: 'Shopping mall',
+          value: 250
+        },
+        {
+          name: 'Transportation',
+          value: 1000
+        },
+        {
+          name: 'Leisure',
+          value: 760
+        }
+      ];
+    }
+
+    var responsiveContent = document.querySelector('as-responsive-content');
+    responsiveContent.addEventListener('ready', onReady);
+
+  </script>
+
+</body>
+
+</html>

--- a/packages/smoke/current/smoke_0.html
+++ b/packages/smoke/current/smoke_0.html
@@ -126,9 +126,15 @@
 
     <aside class="as-sidebar as-sidebar--right">
       <div class="as-container">
-        <as-category-widget class="as-p--16" heading="Business Volume" description="Description" default-bar-color="#47DB99"></as-category-widget>
-        <as-stacked-bar-widget id="stackedSidebar" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
-        <as-histogram-widget id="histogramSidebar" class="as-p--16" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+        <div>
+          <as-category-widget heading="Business Volume" description="Description" default-bar-color="#47DB99"></as-category-widget>
+        </div>
+        <div>
+          <as-stacked-bar-widget id="stackedSidebar" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
+        </div>
+        <div>
+          <as-histogram-widget id="histogramSidebar" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+        </div>
       </div>
     </aside>
   </as-responsive-content>

--- a/packages/smoke/current/smoke_0.html
+++ b/packages/smoke/current/smoke_0.html
@@ -48,7 +48,8 @@
     <i class="as-toolbar__item as-icon-points"></i>
   </as-toolbar>
 
-  <as-responsive-content>
+  <!-- <as-responsive-content> -->
+  <section class="as-content">
     <aside class="as-sidebar as-sidebar--left">
       <div class="as-container">
         <as-tabs>
@@ -115,11 +116,21 @@
 
       </div>
       <footer class="as-map-footer as-bg--complementary">
-        <div class="as-container">
-          <as-stacked-bar-widget id="stackedFooter" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
-        </div>
-        <div class="as-container">
+        <div class="as-container as-container--horizontal">
           <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+        </div>
+        <div class="as-container as-container--scrollable">
+          <div style="display:flex;">
+            <as-stacked-bar-widget id="stackedFooter" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
+            <as-histogram-widget id="histogramSidebar" heading="Title" description="Description" show-header show-clear hidden></as-histogram-widget>
+            <as-category-widget heading="Business Volume" description="Description" default-bar-color="#47DB99"></as-category-widget>
+          </div>
+          <div class="as-box">
+            <h1 class="as-title">A box</h1>
+            <p class="as-body">
+              This content is here to fill up more space.
+            </p>
+          </div>
         </div>
       </footer>
     </main>
@@ -127,17 +138,15 @@
     <aside class="as-sidebar as-sidebar--right">
       <div class="as-container">
         <div>
-          <as-category-widget heading="Business Volume" description="Description" default-bar-color="#47DB99"></as-category-widget>
-        </div>
-        <div>
           <as-stacked-bar-widget id="stackedSidebar" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
         </div>
         <div>
-          <as-histogram-widget id="histogramSidebar" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          
         </div>
       </div>
     </aside>
-  </as-responsive-content>
+  <!-- </as-responsive-content> -->
+  </section>
   <script>
     function onReady () {
       var stackedData = [{
@@ -251,7 +260,11 @@
     }
 
     var responsiveContent = document.querySelector('as-responsive-content');
-    responsiveContent.addEventListener('ready', onReady);
+    if (!responsiveContent) {
+      onReady();
+    } else {
+      responsiveContent.addEventListener('ready', onReady);
+    }
   </script>
 </body>
 

--- a/packages/styles/src/core/layout/_layout.scss
+++ b/packages/styles/src/core/layout/_layout.scss
@@ -23,7 +23,9 @@ body.as-app-body {
     display: flex;
     position: relative;
     flex: 1;
-    height: 100%;
+
+    /* https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox */
+    min-height: 0;
   }
 
   .as-toolbar {

--- a/packages/styles/src/core/layout/main/_main.scss
+++ b/packages/styles/src/core/layout/main/_main.scss
@@ -6,4 +6,5 @@
   position: relative;
   flex: 1;
   flex-direction: column;
+  overflow: auto;
 }


### PR DESCRIPTION
`height: 100%` was causing widgets on FF to not render well, occupying too much space and rendering different from the rest of browsers.