### PR TITLE
Drop IE11 support

### DIFF
--- a/docs/guides/04-styles.md
+++ b/docs/guides/04-styles.md
@@ -133,6 +133,8 @@ To override a CSS class, create a selector matching the element you want to modi
 ```
 
 ### Browser Compatibility
-Airship styles are known to work in latest stable version of all major browsers, and Internet Explorer 11 on Windows.
+Airship styles are known to work in latest stable version of all major modern browsers. Internet Explorer is not supported.
 
 However, we use CSS Variables to provide customization, and they might not be available in all browsers. We provide a fallback for those browsers in order to give the same experience to users, but take it into account when customizing Airship.
+
+

--- a/docs/guides/05-web-components.md
+++ b/docs/guides/05-web-components.md
@@ -73,11 +73,13 @@ Custom Elements are natively supported in Chrome and Safari (including iOS!) and
 
 For browsers without native support, a small polyfill helps developers use Custom Elements seamlessly and with little performance overhead.
 
-Stencil uses a dynamic loader to load the custom elements polyfill only on browsers that need it. With this polyfill Stencil's browser support is Chrome (and all chrome based browsers), Safari, Firefox, Edge, and IE11.
+Stencil uses a dynamic loader to load the custom elements polyfill only on browsers that need it. With this polyfill Stencil's browser support is Chrome (and all chrome based browsers), Safari, Firefox and Edge.
 
 Web Components are being used in production since 2017 with the above approach.
 
+Airship is not supported in Internet Explorer.
 
-| [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="IE / Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) IE / Edge | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) iOS Safari |
+
+| [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="IE / Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) Edge | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/) iOS Safari |
 | --------- | --------- | --------- | --------- | --------- |
-| IE11, Edge+| 63+ | 67+ | 11.1+ | 10.3+
+| Edge+| 63+ | 67+ | 11.1+ | 10.3+

--- a/docs/guides/08-Styling.md
+++ b/docs/guides/08-Styling.md
@@ -118,7 +118,7 @@ componentElement.forEach(element => element.style.setProperty('--panels-bg-color
 ```
 
 ### Customizing Airship with SASS variables
-Even though you have customization through CSS Variables, they might not be suitable for all cases. When supporting IE11, you cannot use CSS variables, and hence you might need to customize styles in build time.
+Even though you have customization through CSS Variables, they might not be suitable for all cases. If you cannot use CSS variables, and hence you might need to customize styles in build time.
 
 Our SASS variables are defined like this:
 ```css

--- a/docs/support/04-browser-support.md
+++ b/docs/support/04-browser-support.md
@@ -1,8 +1,10 @@
 ## Browser Support
 
-Airship works for the last 2 versions in any modern browser and IE11.
+Airship works for the last 2 versions in any modern browser.
+
+Internet Explorer is not supported.
 
 
-| [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="IE / Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>IE / Edge | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>iOS Safari |
+| [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Edge | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>iOS Safari |
 | --------- | --------- | --------- | --------- | --------- |
-| IE11+, Edge+| 63+ | 67+ | 11.1+ | 10.3+
+| Edge+| 63+ | 67+ | 11.1+ | 10.3+


### PR DESCRIPTION
After talking with @rochoa (and getting his approval) we're not going to support IE11 in Airship. CARTO VL doesn't support it either and these two libraries must walk together.

Moreover, the experience of Airship in IE11 is half-baked:
- We need to provide extra polyfills only for it.
- We had to write hacks to render well because of the lack of CSS variables support.
- The overall experience doesn't feel as polished. Flexbox nuances, for instance, make some element combinations to be ugly.
- And more... a lot of effort to get a non good experience.

This PR only modifies the docs. I'll open another one to get rid of the IE11 hacks we've done so far.