### PR TITLE
Rename Stacked Bar render guard

### DIFF
--- a/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.tsx
+++ b/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.tsx
@@ -212,7 +212,7 @@ export class StackedBarWidget {
   }
 
   private _drawFigure() {
-    if (this._containerIsNotDrawable()) {
+    if (!this._isContainerReady()) {
       return;
     }
     requestAnimationFrame(() => {
@@ -261,7 +261,7 @@ export class StackedBarWidget {
   }
 
   // If container is not ready or the widget is invisible block drawing phase
-  private _containerIsNotDrawable() {
+  private _isContainerReady() {
     if (!this.container || this.el.clientWidth === 0 || this.el.clientHeight === 0) {
       return false;
     }


### PR DESCRIPTION
No issue associated, stacked bar widgets were broken on master.