### PR TITLE
Treat null footer and map in `as-responsive-content`

### DIFF
--- a/packages/components/src/components/as-responsive-content/as-responsive-content.e2e.ts
+++ b/packages/components/src/components/as-responsive-content/as-responsive-content.e2e.ts
@@ -17,6 +17,27 @@ describe('as-responsive-content', () => {
       expect(tabsHTML).toContain('Panel 0');
       expect(tabsHTML).toContain('Bottom Bar');
     });
+
+    it('should render tabs even if footer is not available', async () => {
+      page = await newE2EPage({ html: `<as-responsive-content>${noFooterExample}</as-responsive-content>` });
+
+      const tabs: E2EElement = await page.find('.as-toolbar-tabs');
+      const tabsHTML = tabs.innerHTML;
+
+      expect(tabsHTML).toContain('Sidebar 0');
+      expect(tabsHTML).toContain('Sidebar 1');
+      expect(tabsHTML).toContain('Panel 0');
+      expect(tabsHTML).not.toContain('Bottom Bar');
+    });
+
+    it('should not render tabs content is no content is available', async () => {
+      page = await newE2EPage({ html: `<as-responsive-content></as-responsive-content>` });
+
+      const tabs: E2EElement = await page.find('.as-toolbar-tabs');
+      const tabsHTML = tabs.innerHTML;
+
+      expect(tabsHTML).toEqual('');
+    });
   });
 
   describe('Behaviour', async () => {
@@ -69,6 +90,23 @@ const domExample = `
     </div>
 
     <div class="as-map-footer">Bottom Bar</div>
+  </main>
+
+  <aside class="as-sidebar as-sidebar--right">Right Sidebar</aside>
+`;
+
+const noFooterExample = `
+  <aside class="as-sidebar as-sidebar--left">Left Sidebar</aside>
+
+  <main class="as-main">
+    <div class="as-map-area">
+      <div id="map"></div>
+      <div class="as-map-panels">
+        <div class="as-panel as-panel--top as-panel--right">
+          <div class="as-panel__element">Floating Panel</div>
+        </div>
+      </div>
+    </div>
   </main>
 
   <aside class="as-sidebar as-sidebar--right">Right Sidebar</aside>

--- a/packages/components/src/components/as-responsive-content/as-responsive-content.tsx
+++ b/packages/components/src/components/as-responsive-content/as-responsive-content.tsx
@@ -111,7 +111,9 @@ export class ResponsiveContent {
       ...contentService.getSidebars(this.element),
       ...contentService.getPanels(this.element),
       contentService.getFooter(this.element)
-    ];
+    ].filter(section => {
+      return section !== null;
+    });
 
     if (sections.length) {
       sections.sort((a, b) => a.order - b.order);

--- a/packages/components/src/components/as-responsive-content/utils/content.service.ts
+++ b/packages/components/src/components/as-responsive-content/utils/content.service.ts
@@ -3,13 +3,15 @@ import ApplicationSection from './ApplicationSection';
 export function getMap(element: HTMLElement): ApplicationSection {
   const mapElement = element.querySelector('.as-map-area');
 
-  return new ApplicationSection({
-    activeClass: 'as-map-area--visible',
-    element: mapElement,
-    name: mapElement.getAttribute('data-name') || 'Map',
-    order: mapElement.getAttribute('data-tab-order') || 0,
-    type: 'map'
-  });
+  return mapElement
+    ? new ApplicationSection({
+      activeClass: 'as-map-area--visible',
+      element: mapElement,
+      name: mapElement.getAttribute('data-name') || 'Map',
+      order: mapElement.getAttribute('data-tab-order') || 0,
+      type: 'map'
+    })
+    : null;
 }
 
 export function getSidebars(element: HTMLElement): ApplicationSection[] {
@@ -43,13 +45,15 @@ function _getPanel(panelElement: HTMLElement, index: number): ApplicationSection
 export function getFooter(element: HTMLElement): ApplicationSection {
   const footerElement = element.querySelector('.as-map-footer');
 
-  return new ApplicationSection({
-    activeClass: 'as-map-footer--visible',
-    element: footerElement,
-    name: footerElement.getAttribute('data-name') || `Bottom Bar`,
-    order: footerElement.getAttribute('data-tab-order') || 0,
-    type: 'mapFooter'
-  });
+  return footerElement
+    ? new ApplicationSection({
+      activeClass: 'as-map-footer--visible',
+      element: footerElement,
+      name: footerElement.getAttribute('data-name') || `Bottom Bar`,
+      order: footerElement.getAttribute('data-tab-order') || 0,
+      type: 'mapFooter'
+    })
+    : null;
 }
 
 export default {


### PR DESCRIPTION
`as-responsive-content` failed when the map didn't have footer or map.