### PR TITLE
[Hotfix] Responsive content no footer and docs

### DIFF
--- a/examples/components/as-stacked-bar-widget/simple.html
+++ b/examples/components/as-stacked-bar-widget/simple.html
@@ -15,6 +15,7 @@
 
     section {
       width: 40%;
+      height: 256px;
       margin: 30px auto;
     }
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.1"
+  "version": "1.0.2-rc.0"
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/airship-components",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.0",
   "description": "Airship is a set of tools designed to facilitate the development of location intelligence apps by offering layouts, basic patterns, templates, CSS classes, components, widgets and much more.",
   "module": "dist/esm/index.js",
   "main": "dist/index.js",

--- a/packages/components/src/components/as-responsive-content/as-responsive-content.e2e.ts
+++ b/packages/components/src/components/as-responsive-content/as-responsive-content.e2e.ts
@@ -17,6 +17,27 @@ describe('as-responsive-content', () => {
       expect(tabsHTML).toContain('Panel 0');
       expect(tabsHTML).toContain('Bottom Bar');
     });
+
+    it('should render tabs even if footer is not available', async () => {
+      page = await newE2EPage({ html: `<as-responsive-content>${noFooterExample}</as-responsive-content>` });
+
+      const tabs: E2EElement = await page.find('.as-toolbar-tabs');
+      const tabsHTML = tabs.innerHTML;
+
+      expect(tabsHTML).toContain('Sidebar 0');
+      expect(tabsHTML).toContain('Sidebar 1');
+      expect(tabsHTML).toContain('Panel 0');
+      expect(tabsHTML).not.toContain('Bottom Bar');
+    });
+
+    it('should not render tabs content is no content is available', async () => {
+      page = await newE2EPage({ html: `<as-responsive-content></as-responsive-content>` });
+
+      const tabs: E2EElement = await page.find('.as-toolbar-tabs');
+      const tabsHTML = tabs.innerHTML;
+
+      expect(tabsHTML).toEqual('');
+    });
   });
 
   describe('Behaviour', async () => {
@@ -69,6 +90,23 @@ const domExample = `
     </div>
 
     <div class="as-map-footer">Bottom Bar</div>
+  </main>
+
+  <aside class="as-sidebar as-sidebar--right">Right Sidebar</aside>
+`;
+
+const noFooterExample = `
+  <aside class="as-sidebar as-sidebar--left">Left Sidebar</aside>
+
+  <main class="as-main">
+    <div class="as-map-area">
+      <div id="map"></div>
+      <div class="as-map-panels">
+        <div class="as-panel as-panel--top as-panel--right">
+          <div class="as-panel__element">Floating Panel</div>
+        </div>
+      </div>
+    </div>
   </main>
 
   <aside class="as-sidebar as-sidebar--right">Right Sidebar</aside>

--- a/packages/components/src/components/as-responsive-content/as-responsive-content.tsx
+++ b/packages/components/src/components/as-responsive-content/as-responsive-content.tsx
@@ -111,7 +111,9 @@ export class ResponsiveContent {
       ...contentService.getSidebars(this.element),
       ...contentService.getPanels(this.element),
       contentService.getFooter(this.element)
-    ];
+    ].filter(section => {
+      return section !== null;
+    });
 
     if (sections.length) {
       sections.sort((a, b) => a.order - b.order);

--- a/packages/components/src/components/as-responsive-content/as-responsive-content.tsx
+++ b/packages/components/src/components/as-responsive-content/as-responsive-content.tsx
@@ -111,7 +111,7 @@ export class ResponsiveContent {
       ...contentService.getSidebars(this.element),
       ...contentService.getPanels(this.element),
       contentService.getFooter(this.element)
-    ].filter(section => {
+    ].filter((section) => {
       return section !== null;
     });
 

--- a/packages/components/src/components/as-responsive-content/utils/content.service.ts
+++ b/packages/components/src/components/as-responsive-content/utils/content.service.ts
@@ -3,13 +3,15 @@ import ApplicationSection from './ApplicationSection';
 export function getMap(element: HTMLElement): ApplicationSection {
   const mapElement = element.querySelector('.as-map-area');
 
-  return new ApplicationSection({
-    activeClass: 'as-map-area--visible',
-    element: mapElement,
-    name: mapElement.getAttribute('data-name') || 'Map',
-    order: mapElement.getAttribute('data-tab-order') || 0,
-    type: 'map'
-  });
+  return mapElement
+    ? new ApplicationSection({
+      activeClass: 'as-map-area--visible',
+      element: mapElement,
+      name: mapElement.getAttribute('data-name') || 'Map',
+      order: mapElement.getAttribute('data-tab-order') || 0,
+      type: 'map'
+    })
+    : null;
 }
 
 export function getSidebars(element: HTMLElement): ApplicationSection[] {
@@ -43,13 +45,15 @@ function _getPanel(panelElement: HTMLElement, index: number): ApplicationSection
 export function getFooter(element: HTMLElement): ApplicationSection {
   const footerElement = element.querySelector('.as-map-footer');
 
-  return new ApplicationSection({
-    activeClass: 'as-map-footer--visible',
-    element: footerElement,
-    name: footerElement.getAttribute('data-name') || `Bottom Bar`,
-    order: footerElement.getAttribute('data-tab-order') || 0,
-    type: 'mapFooter'
-  });
+  return footerElement
+    ? new ApplicationSection({
+      activeClass: 'as-map-footer--visible',
+      element: footerElement,
+      name: footerElement.getAttribute('data-name') || `Bottom Bar`,
+      order: footerElement.getAttribute('data-tab-order') || 0,
+      type: 'mapFooter'
+    })
+    : null;
 }
 
 export default {

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -2,3 +2,4 @@
 Airship is a set of tools designed to facilitate the development of location intelligence apps by offering layouts, basic patterns, templates, CSS classes, components, widgets and much more.
 
 Please refer to [Airship documentation](https://carto.com/developers/airship/) to know more about Airship and go to [Airship Icons guide](https://carto.com/developers/airship/guides/icons/) to get started and know more about this package.
+

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/airship-icons",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.0",
   "description": "Airship is a set of tools designed to facilitate the development of location intelligence apps by offering layouts, basic patterns, templates, CSS classes, components, widgets and much more.",
   "files": [
     "dist/"

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -2,3 +2,4 @@
 Airship is a set of tools designed to facilitate the development of location intelligence apps by offering layouts, basic patterns, templates, CSS classes, components, widgets and much more.
 
 Please refer to [Airship documentation](https://carto.com/developers/airship/) to know more about Airship, and go to [Airship Components guide](https://carto.com/developers/airship/guides/styles/) to get started and know more about this package.
+

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/airship-style",
-  "version": "1.0.1",
+  "version": "1.0.2-rc.0",
   "description": "Airship is a set of tools designed to facilitate the development of location intelligence apps by offering layouts, basic patterns, templates, CSS classes, components, widgets and much more.",
   "main": "src/airship.scss",
   "files": [

--- a/packages/styles/src/core/layout/main/map-footer/README.md
+++ b/packages/styles/src/core/layout/main/map-footer/README.md
@@ -55,7 +55,7 @@ showSource: true
 noSource: true
 responsive: true
 ---
-<iframe src="/examples/layouts/footer/footer" style="width: 100%; height: 100%;">
+<iframe src="/examples/layouts/footer/footer.html" style="width: 100%; height: 100%;">
 ```
 
 ## Footer content


### PR DESCRIPTION
`as-responsive-content` failed if there were no footer nor map in the page.

Fixed two minor doc bugs also.