### PR TITLE
Fix histogram for floating values

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postinstall": "lerna bootstrap --hoist",
     "publish": "npm install && npm run test && npm run build && lerna publish && ./release.sh",
     "publish:prerelease": "npm install && npm run test && npm run build && lerna publish --npm-tag prerelease && ./prerelease.sh",
-    "serve": "serve && open http://localhost:5000",
+    "serve": "serve",
     "test:components:watch": "lerna exec --scope @carto/airship-components -- npm run test:watch",
     "test:components": "lerna exec --scope @carto/airship-components npm run test",
     "test:styles:build-references": "npm run build:styles && docker run --rm -v $(pwd):/src backstopjs/backstopjs reference --i --configPath=backstop_data/backstop.config.js",

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -73,6 +73,10 @@ as-histogram-widget {
       .tick line {
         display: none;
       }
+
+      .tick:last-of-type text {
+        transform: translateX(-10px);
+      }
     }
 
     .handle--wrapper {

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.scss
@@ -92,7 +92,7 @@ as-histogram-widget {
     }
 
     .handle--grab {
-      transform: translateY(12px);
+      transform: translateY(5px);
     }
 
     .grab-line {

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -24,7 +24,7 @@ const DEFAULT_BAR_COLOR = `var(--as--color--primary, ${DEFAULT_BAR_COLOR_HEX})`;
 const DEFAULT_SELECTED_BAR_COLOR = `var(--as--color--complementary, ${DEFAULT_SELECTED_BAR_COLOR_HEX})`;
 const BARS_SEPARATION = 1;
 const CUSTOM_HANDLE_WIDTH = BARS_SEPARATION + 5;
-const CUSTOM_HANDLE_HEIGHT = 28;
+const CUSTOM_HANDLE_HEIGHT = 14;
 
 // we could use getComputedStyle instead of these
 const X_PADDING = 38;

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -534,7 +534,7 @@ export class HistogramWidget {
 
     // Convert to our data's domain
     const d0 = evt.selection
-      .map((selection) => Math.round(this.xScale.invert(selection)))
+      .map((selection) => this.xScale.invert(selection))
       .map((bucket) => this.binsScale.invert(bucket));
 
     this._setSelection(d0);

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -13,7 +13,7 @@ import { shadeOrBlend } from '../../utils/styles';
 import contentFragment from '../common/content.fragment';
 import { HistogramColorRange, HistogramData } from './interfaces';
 import { Container } from './types/Container';
-import dataService from './utils/data.service';
+import dataService, { binsScale } from './utils/data.service';
 import drawService from './utils/draw.service';
 
 // This is the default value of --as--color--primary
@@ -184,6 +184,7 @@ export class HistogramWidget {
   private tooltipElement: HTMLElement;
 
   private xScale: ScaleLinear<number, number>;
+  private binsScale: ScaleLinear<number, number>;
   private yScale: ScaleLinear<number, number>;
   private barsContainer: Container;
   private brush: BrushBehavior<{}>;
@@ -202,6 +203,11 @@ export class HistogramWidget {
 
   constructor() {
     this._resizeRender = this._resizeRender.bind(this);
+  }
+
+  @Watch('data')
+  public _onDataChanged(newData) {
+    this.binsScale = binsScale(newData);
   }
 
   @Watch('color')
@@ -268,6 +274,8 @@ export class HistogramWidget {
     if (!this._hasDataToDisplay()) {
       return;
     }
+
+    this.binsScale = binsScale(this.data);
 
     this._renderGraph();
   }
@@ -526,7 +534,8 @@ export class HistogramWidget {
 
     // Convert to our data's domain
     const d0 = evt.selection
-      .map((e) => Math.round(this.xScale.invert(e)));
+      .map((selection) => Math.round(this.xScale.invert(selection)))
+      .map((bucket) => this.binsScale.invert(bucket));
 
     this._setSelection(d0);
   }
@@ -589,6 +598,7 @@ export class HistogramWidget {
 
     // Convert back to space coordinates
     const valuesSpace = values
+      .map(this.binsScale)
       .map(this.xScale);
 
     this.brushArea.call(this.brush.move, valuesSpace);
@@ -629,6 +639,7 @@ export class HistogramWidget {
     const xAxis = drawService.renderXAxis(
       this.container,
       xDomain,
+      this.data.length,
       X_PADDING + (this.yLabel ? LABEL_PADDING : 0),
       Y_PADDING);
 

--- a/packages/components/src/components/as-histogram-widget/utils/data.service.ts
+++ b/packages/components/src/components/as-histogram-widget/utils/data.service.ts
@@ -3,6 +3,12 @@ import { ScaleLinear, scaleLinear } from 'd3-scale';
 import { HistogramData } from '../interfaces';
 import { Domain } from '../types/Domain';
 
+export function binsScale(data: HistogramData[]) {
+  return scaleLinear()
+    .domain(getXDomain(data))
+    .range([0, data.length]);
+}
+
 export function getXDomain(data: HistogramData[]): Domain {
   const { start } = data.length > 0 ? data[0] : { start: 0 };
   const { end } = data.length > 0 ? data[data.length - 1] : { end: 0 };

--- a/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
+++ b/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
@@ -39,6 +39,7 @@ export function updateAxes(
 }
 
 const formatter = format('.2~s');
+const decimalFormatter = format('.2');
 
 export function renderBars(
   data: HistogramData[],
@@ -110,7 +111,15 @@ export function renderXAxis(
     .tickSize(-WIDTH)
     .ticks(3)
     .tickPadding(10)
-    .tickFormat((value) => formatter(realScale.invert(value)));
+    .tickFormat((value) => {
+      const realValue = realScale.invert(value);
+
+      if (realValue > 0 && realValue < 1) {
+        return decimalFormatter(realValue);
+      }
+
+      return formatter(realValue);
+    });
 
   if (container.select('.x-axis').empty()) {
     container
@@ -147,7 +156,13 @@ export function renderYAxis(
     .tickSize(-WIDTH)
     .ticks(5)
     .tickPadding(10)
-    .tickFormat(formatter);
+    .tickFormat((value) => {
+      if (value > 0 && value < 1) {
+        return decimalFormatter(value);
+      }
+
+      return formatter(value);
+    });
 
   if (container.select('.y-axis').empty()) {
     container

--- a/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
+++ b/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
@@ -117,11 +117,7 @@ export function renderXAxis(
     .tickFormat((value) => {
       const realValue = realScale.invert(value);
 
-      if (realValue > 0 && realValue < 1) {
-        return decimalFormatter(realValue);
-      }
-
-      return formatter(realValue);
+      return _conditionalFormatter(realValue);
     });
 
   if (container.select('.x-axis').empty()) {
@@ -159,13 +155,7 @@ export function renderYAxis(
     .tickSize(-WIDTH)
     .ticks(5)
     .tickPadding(10)
-    .tickFormat((value) => {
-      if (value > 0 && value < 1) {
-        return decimalFormatter(value);
-      }
-
-      return formatter(value);
-    });
+    .tickFormat(_conditionalFormatter);
 
   if (container.select('.y-axis').empty()) {
     container
@@ -182,6 +172,14 @@ export function renderYAxis(
 
 function _delayFn(_d, i) {
   return i;
+}
+
+function _conditionalFormatter(value) {
+  if (value > 0 && value < 1) {
+    return decimalFormatter(value);
+  }
+
+  return formatter(value);
 }
 
 export default { cleanAxes, updateAxes, renderBars, renderXAxis, renderYAxis };

--- a/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
+++ b/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
@@ -99,6 +99,9 @@ export function renderXAxis(
   const HEIGHT = container.node().getBoundingClientRect().height - Y_PADDING;
   const WIDTH = container.node().getBoundingClientRect().width - X_PADDING;
 
+  // Display first, last and middle point bins
+  const ticks = [0, bins / 2, bins];
+
   const xScale = scaleLinear()
     .domain([0, bins])
     .range([0, WIDTH]);
@@ -109,7 +112,7 @@ export function renderXAxis(
 
   const xAxis = axisBottom(xScale)
     .tickSize(-WIDTH)
-    .ticks(3)
+    .tickValues(ticks)
     .tickPadding(10)
     .tickFormat((value) => {
       const realValue = realScale.invert(value);

--- a/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
+++ b/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
@@ -38,6 +38,8 @@ export function updateAxes(
     .call(yAxis);
 }
 
+const formatter = format('.2~s');
+
 export function renderBars(
   data: HistogramData[],
   yScale: ScaleLinear<number, number>,
@@ -89,6 +91,7 @@ export function renderBars(
 export function renderXAxis(
   container: Container,
   domain: Domain,
+  bins: number,
   X_PADDING: number,
   Y_PADDING: number): Axis<{ valueOf(): number }> {
 
@@ -96,13 +99,18 @@ export function renderXAxis(
   const WIDTH = container.node().getBoundingClientRect().width - X_PADDING;
 
   const xScale = scaleLinear()
-    .domain(domain)
+    .domain([0, bins])
     .range([0, WIDTH]);
+
+  const realScale = scaleLinear()
+    .domain(domain)
+    .range([0, bins]);
 
   const xAxis = axisBottom(xScale)
     .tickSize(-WIDTH)
     .ticks(3)
-    .tickPadding(10);
+    .tickPadding(10)
+    .tickFormat((value) => formatter(realScale.invert(value)));
 
   if (container.select('.x-axis').empty()) {
     container
@@ -139,7 +147,7 @@ export function renderYAxis(
     .tickSize(-WIDTH)
     .ticks(5)
     .tickPadding(10)
-    .tickFormat(format('.2~s'));
+    .tickFormat(formatter);
 
   if (container.select('.y-axis').empty()) {
     container

--- a/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
+++ b/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
@@ -163,7 +163,7 @@ export function renderYAxis(
 }
 
 function _delayFn(_d, i) {
-  return i * 50;
+  return i;
 }
 
 export default { cleanAxes, updateAxes, renderBars, renderXAxis, renderYAxis };

--- a/packages/smoke/current/smoke_0.html
+++ b/packages/smoke/current/smoke_0.html
@@ -248,28 +248,28 @@
       stackedSidebar.metadata = stackedMetadata;
 
       var histogramData =  [{
-          start: 0,
-          end: 10,
+          start: 0.2,
+          end: 0.4,
           value: 5
         },
         {
-          start: 10,
-          end: 20,
+          start: 0.4,
+          end: 0.6,
           value: 10
         },
         {
-          start: 20,
-          end: 30,
+          start: 0.6,
+          end: 0.8,
           value: 15
         },
         {
-          start: 30,
-          end: 40,
+          start: 0.8,
+          end: 1,
           value: 20
         },
         {
-          start: 40,
-          end: 50,
+          start: 1,
+          end: 1.2,
           value: 30
         },
       ];


### PR DESCRIPTION
Fix #496 
---

The real reason why this happens is a Math.round, but it also solves a very annoying case where moving the whole selection could potentially shrink or grow when reaching the start or the end of the histogram.

I've changed it so an internal scale is used that always goes from 0 to # of bins, and is converted back for the event fired.