### PR TITLE
Make space between bars adapt to available space

### DIFF
--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -22,8 +22,7 @@ const DEFAULT_BAR_COLOR_HEX = '#1785FB';
 const DEFAULT_SELECTED_BAR_COLOR_HEX = '#1785FB';
 const DEFAULT_BAR_COLOR = `var(--as--color--primary, ${DEFAULT_BAR_COLOR_HEX})`;
 const DEFAULT_SELECTED_BAR_COLOR = `var(--as--color--complementary, ${DEFAULT_SELECTED_BAR_COLOR_HEX})`;
-const BARS_SEPARATION = 1;
-const CUSTOM_HANDLE_WIDTH = BARS_SEPARATION + 5;
+const CUSTOM_HANDLE_WIDTH = 6;
 const CUSTOM_HANDLE_HEIGHT = 28;
 
 // we could use getComputedStyle instead of these
@@ -452,7 +451,6 @@ export class HistogramWidget {
         this.yScale,
         this.container,
         this.barsContainer,
-        BARS_SEPARATION,
         this._color,
         X_PADDING + (this.yLabel ? LABEL_PADDING : 0),
         Y_PADDING,

--- a/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
+++ b/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
@@ -50,14 +50,14 @@ export function renderBars(
   Y_PADDING: number,
   disableAnimation: boolean = false) {
 
-  let BARS_SEPARATION = 1;
+  let barsSeparation = 1;
   const HEIGHT = container.node().getBoundingClientRect().height - Y_PADDING;
   const WIDTH = container.node().getBoundingClientRect().width - X_PADDING;
 
   const barWidth = data.length === 0 ? WIDTH : WIDTH / data.length;
 
-  if (barWidth - BARS_SEPARATION < BAR_WIDTH_THRESHOLD) {
-    BARS_SEPARATION = 0;
+  if (barWidth - barsSeparation < BAR_WIDTH_THRESHOLD) {
+    barsSeparation = 0;
   }
 
   // -- Draw bars
@@ -79,7 +79,7 @@ export function renderBars(
       .merge(this.bars)
       .attr('class', 'bar')
       .attr('x', (_d: HistogramData, index: number) => index * barWidth)
-      .attr('width', () => Math.max(0, barWidth - BARS_SEPARATION))
+      .attr('width', () => Math.max(0, barWidth - barsSeparation))
       .style('fill', (d: HistogramData) => d.color || color);
 
   (disableAnimation ? mergeSelection : mergeSelection.transition().delay(_delayFn))

--- a/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
+++ b/packages/components/src/components/as-histogram-widget/utils/draw.service.ts
@@ -6,6 +6,8 @@ import { HistogramData } from '../interfaces';
 import { Container } from '../types/Container';
 import { Domain } from '../types/Domain';
 
+const BAR_WIDTH_THRESHOLD = 3;
+
 export function cleanAxes(yAxisSelection: Container) {
   yAxisSelection.select('.domain').remove();
 }
@@ -43,16 +45,20 @@ export function renderBars(
   yScale: ScaleLinear<number, number>,
   container: Container,
   barsContainer: Container,
-  BARS_SEPARATION: number,
   color: string,
   X_PADDING: number,
   Y_PADDING: number,
   disableAnimation: boolean = false) {
 
+  let BARS_SEPARATION = 1;
   const HEIGHT = container.node().getBoundingClientRect().height - Y_PADDING;
   const WIDTH = container.node().getBoundingClientRect().width - X_PADDING;
 
   const barWidth = data.length === 0 ? WIDTH : WIDTH / data.length;
+
+  if (barWidth - BARS_SEPARATION < BAR_WIDTH_THRESHOLD) {
+    BARS_SEPARATION = 0;
+  }
 
   // -- Draw bars
   this.bars = barsContainer

--- a/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.tsx
+++ b/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.tsx
@@ -9,6 +9,8 @@ import colorMapFactory from './utils/colorMap.factory';
 import dataService from './utils/data.service';
 import drawService from './utils/draw.service';
 
+const BAR_WIDTH_THRESHOLD = 3;
+
 /**
  * Stacked bar Widget
  *
@@ -226,9 +228,16 @@ export class StackedBarWidget {
       return;
     }
     const Y_AXIS_LABEL_WIDTH = 25; // We draw on the right of the yAxis labels
-    const COLUMN_MARGIN = 4;
-    const WIDTH = yAxisElement.getBoundingClientRect().width - Y_AXIS_LABEL_WIDTH - COLUMN_MARGIN;
-    const COLUMN_WIDTH = (WIDTH / this.data.length) - COLUMN_MARGIN;
+    let COLUMN_MARGIN = 4;
+    let WIDTH = yAxisElement.getBoundingClientRect().width - Y_AXIS_LABEL_WIDTH - COLUMN_MARGIN;
+    let COLUMN_WIDTH = (WIDTH / this.data.length) - COLUMN_MARGIN;
+
+    if (COLUMN_WIDTH < BAR_WIDTH_THRESHOLD) {
+      WIDTH += COLUMN_MARGIN;
+      COLUMN_WIDTH += COLUMN_MARGIN;
+      COLUMN_MARGIN = 0;
+    }
+
     const data = dataService.rawDataToStackBarData(this.data, this.scale, this.colorMap, COLUMN_WIDTH, COLUMN_MARGIN);
 
     drawService.drawColumns(this.container, data, this.mouseOver, this.mouseLeave);

--- a/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.tsx
+++ b/packages/components/src/components/as-stacked-bar-widget/as-stacked-bar-widget.tsx
@@ -228,17 +228,17 @@ export class StackedBarWidget {
       return;
     }
     const Y_AXIS_LABEL_WIDTH = 25; // We draw on the right of the yAxis labels
-    let COLUMN_MARGIN = 4;
-    let WIDTH = yAxisElement.getBoundingClientRect().width - Y_AXIS_LABEL_WIDTH - COLUMN_MARGIN;
-    let COLUMN_WIDTH = (WIDTH / this.data.length) - COLUMN_MARGIN;
+    let columnMargin = 4;
+    let WIDTH = yAxisElement.getBoundingClientRect().width - Y_AXIS_LABEL_WIDTH - columnMargin;
+    let COLUMN_WIDTH = (WIDTH / this.data.length) - columnMargin;
 
     if (COLUMN_WIDTH < BAR_WIDTH_THRESHOLD) {
-      WIDTH += COLUMN_MARGIN;
-      COLUMN_WIDTH += COLUMN_MARGIN;
-      COLUMN_MARGIN = 0;
+      WIDTH += columnMargin;
+      COLUMN_WIDTH += columnMargin;
+      columnMargin = 0;
     }
 
-    const data = dataService.rawDataToStackBarData(this.data, this.scale, this.colorMap, COLUMN_WIDTH, COLUMN_MARGIN);
+    const data = dataService.rawDataToStackBarData(this.data, this.scale, this.colorMap, COLUMN_WIDTH, columnMargin);
 
     drawService.drawColumns(this.container, data, this.mouseOver, this.mouseLeave);
   }


### PR DESCRIPTION
Fix #519 
---

This PR makes the bars separation a bit smarter. As the code is right now, if you have enough bars and not enough space, the stacked bar might even crash due to negative bar size.

Now, if the projected bar width falls under a certain threshold (3px because why not), the separation between bars is set to 0.

The result is this:
![abelqueteparece](https://user-images.githubusercontent.com/446970/48919295-3a90bc80-ee92-11e8-885a-ccc55ae41012.gif)

Same for the histogram, though it's less likely because the bar separation is 1 instead of 4.

/cc @AbelVm