### PR TITLE
Don't fire selectionChanged event when data just updated

### DIFF
--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -23,7 +23,7 @@ const DEFAULT_SELECTED_BAR_COLOR_HEX = '#1785FB';
 const DEFAULT_BAR_COLOR = `var(--as--color--primary, ${DEFAULT_BAR_COLOR_HEX})`;
 const DEFAULT_SELECTED_BAR_COLOR = `var(--as--color--complementary, ${DEFAULT_SELECTED_BAR_COLOR_HEX})`;
 const CUSTOM_HANDLE_WIDTH = 6;
-const CUSTOM_HANDLE_HEIGHT = 28;
+const CUSTOM_HANDLE_HEIGHT = 14;
 
 // we could use getComputedStyle instead of these
 const X_PADDING = 38;


### PR DESCRIPTION
Related #525 
---

We should never fire selectionChanged events if we're repainting (and thus, updating the handles) because of a data change.

Also fixed a regression introduced on a recent merge with the selection bars.