### PR TITLE
Use node-sass in watch mode for styles

### DIFF
--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -19,7 +19,7 @@
     "build": "npm run build:min && npm run build:css && node scripts/add-banner.js",
     "build:css": "node-sass src -o dist",
     "build:min": "node-sass src -o dist --output-style compressed && sh scripts/rename-css-files.sh",
-    "dev": "sass --watch src:dist",
+    "dev": "node-sass --watch src -o dist",
     "lint:fix": "stylelint 'src/**/*.scss' --fix",
     "lint": "stylelint 'src/**/*.scss'"
   },


### PR DESCRIPTION
`npm run dev` in styles package fails in an installation from scratch.

This PR uses `node-sass` in `dev` mode. We are using it in build mode.

