### PR TITLE
Set min value or max value when mouse is past edge bounds

### DIFF
--- a/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
+++ b/packages/components/src/components/as-range-slider/slider/as-range-slider.tsx
@@ -304,7 +304,7 @@ export class RangeSlider {
   }
 
   private _getStepValue(value) {
-    const stepValue = Math.round(value / this.step) * this.step;
+    const stepValue = Math.max(this.minValue, Math.round(value / this.step) * this.step);
     return this.roundToStep(stepValue, this.step);
   }
 

--- a/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
+++ b/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
@@ -122,12 +122,16 @@ export class RangeSliderThumb {
     const eventX = changedTouches ? changedTouches[0].pageX : (event as MouseEvent).pageX;
     const barPercentage = (eventX - this.railBoundingClientRect.left) * 100 / this.railElement.offsetWidth;
 
-    if (barPercentage < 0) {
+    if (barPercentage < 0 && this.percentage > 0) {
       return this.thumbMove.emit(0);
     }
 
-    if (barPercentage > 100) {
+    if (barPercentage > 100 && this.percentage < 100) {
       return this.thumbMove.emit(100);
+    }
+
+    if (barPercentage < 0 || barPercentage > 100) {
+      return;
     }
 
     this.thumbMove.emit(barPercentage);

--- a/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
+++ b/packages/components/src/components/as-range-slider/thumb/as-range-slider-thumb.tsx
@@ -122,8 +122,12 @@ export class RangeSliderThumb {
     const eventX = changedTouches ? changedTouches[0].pageX : (event as MouseEvent).pageX;
     const barPercentage = (eventX - this.railBoundingClientRect.left) * 100 / this.railElement.offsetWidth;
 
-    if (barPercentage < 0 || barPercentage > 100) {
-      return;
+    if (barPercentage < 0) {
+      return this.thumbMove.emit(0);
+    }
+
+    if (barPercentage > 100) {
+      return this.thumbMove.emit(100);
     }
 
     this.thumbMove.emit(barPercentage);


### PR DESCRIPTION
This PR sets min or max value when mouse is past range slider bounds.

There were some cases when sliding mouse so fast to the left didn't fire some `mousemove` events that are necessary to set slider thumb to the left most position. It should happen with the right one as well.