### PR TITLE
Range slider filter for VL Bridge

### DIFF
--- a/packages/bridge/examples/range.html
+++ b/packages/bridge/examples/range.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
-    <title>Airship histogram & Category widget bridge example</title>
+    <title>Airship range filter example</title>
 
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
     <!-- <script src="https://libs.cartocdn.com/carto-vl/v1.1.1/carto-vl.js"></script> -->

--- a/packages/bridge/examples/range.html
+++ b/packages/bridge/examples/range.html
@@ -1,0 +1,119 @@
+
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+
+    <title>Airship histogram & Category widget bridge example</title>
+
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
+    <!-- <script src="https://libs.cartocdn.com/carto-vl/v1.1.1/carto-vl.js"></script> -->
+    <script src="/packages/bridge/lib/carto-vl.js"></script>
+
+    <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.50.0/mapbox-gl.css" rel="stylesheet" />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.50.0/mapbox-gl.js"></script>
+
+    <link rel="stylesheet" href="/packages/styles/dist/airship.css">
+    <script src="/packages/components/dist/airship.js"></script>
+    <script src="/packages/bridge/dist/asbridge.js"></script>
+</head>
+
+<body class="as-app-body">
+    <div class="as-app">
+        <div class="as-content">
+            <main class="as-main">
+              <div class="as-map-area">
+                  <div id="map"></div>
+              </div>
+            </main>
+            <aside class="as-sidebar as-sidebar--left">
+              <div class="as-container">
+                <div class="as-box">
+                  <h2 class="as-subheader">Filter longitude</h2>
+                  <as-range-slider
+                    id="lonRange"
+                  >
+                  </as-range-slider>
+                </div>
+                <div class="as-box">
+                  <h2 class="as-subheader">Filter latitude</h2>
+                  <as-range-slider
+                    id="latRange"
+                  >
+                  </as-range-slider>
+                </div>
+                <div class="as-box">
+                  <as-histogram-widget
+                    show-clear
+                    id="typeHist"
+                    heading="Type"
+                  >
+                  </as-histogram-widget>
+                </div>
+              </div>
+            </aside>
+        </div>
+    </div>
+
+    <script>
+        const map = new mapboxgl.Map({
+          container: 'map',
+          style: carto.basemaps.darkmatter,
+          center: [-4.77, 37.88],
+          zoom: 4
+        });
+
+        carto.setDefaultAuth({
+          username: 'roman-carto',
+          apiKey: 'default_public'
+        });
+
+        const s = carto.expressions;
+
+        const source = new carto.source.SQL(`select *, ST_X(the_geom) as lon, ST_Y(the_geom) as lat from ne_10m_airports`);
+        const viz = new carto.Viz(`
+          strokeWidth: 0
+          color: ramp($location, vivid)
+        `);
+
+        const vizLayer = new carto.Layer('layer', source, viz);
+
+        const typeHistogram = document.querySelector('#typeHist');
+        const lonRange = document.querySelector('#lonRange');
+        const latRange = document.querySelector('#latRange');
+
+        lonRange.formatValue = latRange.formatValue = (value) => `${Math.floor(value)}º`;
+
+        vizLayer.addTo(map, 'watername_ocean');
+
+        const bridge = new AsBridge.VLBridge(
+          carto,
+          map,
+          vizLayer,
+          source
+        );
+
+        bridge.histogram({
+          column: 'location',
+          readOnly: false,
+          widget: typeHistogram,
+        }).enableColorMapping();
+
+        bridge.globalRange({
+          column: 'lon',
+          widget: lonRange
+        });
+
+        bridge.globalRange({
+          column: 'lat',
+          widget: latRange
+        });
+
+        bridge.build();
+    </script>
+</body>
+
+</html>

--- a/packages/bridge/src/types.d.ts
+++ b/packages/bridge/src/types.d.ts
@@ -158,3 +158,21 @@ interface CategoricalHistogramOptions {
    */
   widget: HTMLAsHistogramWidgetElement;
 }
+
+interface GlobalRangeOptions {
+  /**
+   * The HTML Element for an Airship as-range-slider
+   *
+   * @type {HTMLAsRangeSliderElement}
+   * @memberof GlobalRangeOptions
+   */
+  widget: HTMLAsRangeSliderElement;
+
+  /**
+   * The column you want to filter using the range slider
+   *
+   * @type {string}
+   * @memberof GlobalRangeOptions
+   */
+  column: string;
+}

--- a/packages/bridge/src/vl/VLBridge.ts
+++ b/packages/bridge/src/vl/VLBridge.ts
@@ -3,8 +3,8 @@ import { BaseFilter } from './base/BaseFilter';
 import { CategoryFilter } from './category/CategoryFilter';
 import { CategoricalHistogramFilter } from './histogram/CategoricalHistogramFilter';
 import { NumericalHistogramFilter } from './histogram/NumericalHistogramFilter';
-import { TimeSeries } from './time-series/TimeSeries';
 import { GlobalRangeFilter } from './range/GlobalRangeFilter';
+import { TimeSeries } from './time-series/TimeSeries';
 
 const VL_VERSION = '^1.1.0';
 
@@ -219,8 +219,8 @@ export default class VLBridge {
       buckets,
       column,
       readOnly,
-      widget,
-      totals
+      totals,
+      widget
     });
 
     histogram.setTimeSeries(true);

--- a/packages/bridge/src/vl/VLBridge.ts
+++ b/packages/bridge/src/vl/VLBridge.ts
@@ -4,6 +4,7 @@ import { CategoryFilter } from './category/CategoryFilter';
 import { CategoricalHistogramFilter } from './histogram/CategoricalHistogramFilter';
 import { NumericalHistogramFilter } from './histogram/NumericalHistogramFilter';
 import { TimeSeries } from './time-series/TimeSeries';
+import { GlobalRangeFilter } from './range/GlobalRangeFilter';
 
 const VL_VERSION = '^1.1.0';
 
@@ -227,6 +228,17 @@ export default class VLBridge {
     histogram.on('rangeChanged', (range) => {
       this._animation.setRange(range);
     });
+  }
+
+  public globalRange({
+    column,
+    widget
+  }: GlobalRangeOptions) {
+    const range = new GlobalRangeFilter(this._carto, this._layer, widget, column, this._source);
+
+    this._addFilter(range);
+
+    return range;
   }
 
   /**

--- a/packages/bridge/src/vl/range/GlobalRangeFilter.ts
+++ b/packages/bridge/src/vl/range/GlobalRangeFilter.ts
@@ -1,0 +1,63 @@
+import { BaseFilter } from '../base/BaseFilter';
+
+/**
+ * Class that binds a CARTO VL between filter to an Airship range slider widget
+ *
+ * @export
+ * @class GlobalRangeFilter
+ * @extends {BaseFilter}
+ */
+export class GlobalRangeFilter extends BaseFilter {
+  protected _widget: HTMLAsRangeSliderElement;
+  private _carto: any;
+  private _dataLayer: any;
+  private _populated: boolean;
+  private _value: [number, number] = null;
+
+  constructor(
+    carto: any,
+    layer: any,
+    widget: HTMLAsRangeSliderElement,
+    columnName: string,
+    source: any
+  ) {
+    super(`category`, columnName, layer, source, false);
+
+    this._widget = widget;
+    this._carto = carto;
+
+    this._widget.addEventListener('change', (event: CustomEvent) => {
+      this._value = event.detail;
+      this._filterChanged();
+    });
+  }
+
+  public setDataLayer(layer: any) {
+    this._dataLayer = layer;
+
+    this._dataLayer.on('updated', () => {
+      const data = this._dataLayer.viz.variables[this.name];
+
+      if (data && !this._populated) {
+        this._widget.minValue = data.value[0];
+        this._widget.maxValue = data.value[1];
+        this._widget.range = data.value;
+
+        this._populated = true;
+      }
+    });
+  }
+
+  public get filter(): string {
+    if (this._value === null) {
+      return null
+    } else {
+      return `$${this.column} > ${this._value[0]} and $${this.column} < ${this._value[1]}`;
+    }
+  }
+
+  public get expression(): any {
+    const s = this._carto.expressions;
+    return s.list([s.globalMin(s.prop(this._column)), s.globalMax(s.prop(this._column))])
+  }
+}

--- a/packages/bridge/src/vl/range/GlobalRangeFilter.ts
+++ b/packages/bridge/src/vl/range/GlobalRangeFilter.ts
@@ -50,7 +50,7 @@ export class GlobalRangeFilter extends BaseFilter {
 
   public get filter(): string {
     if (this._value === null) {
-      return null
+      return null;
     } else {
       return `$${this.column} > ${this._value[0]} and $${this.column} < ${this._value[1]}`;
     }
@@ -58,6 +58,6 @@ export class GlobalRangeFilter extends BaseFilter {
 
   public get expression(): any {
     const s = this._carto.expressions;
-    return s.list([s.globalMin(s.prop(this._column)), s.globalMax(s.prop(this._column))])
+    return s.list([s.globalMin(s.prop(this._column)), s.globalMax(s.prop(this._column))]);
   }
 }

--- a/packages/bridge/src/vl/range/README.md
+++ b/packages/bridge/src/vl/range/README.md
@@ -1,0 +1,61 @@
+## Global Range VL Bridge
+
+Use this in order to connect a numerical column to an Airship range slider. The widget will automatically fetch the global mininum and maximum values of the column and set it on the widget.
+
+All the event handling will be done so the widget filters the visualization. Since this is a 'global' filter, it is not affected by other filters.
+
+### Usage
+
+As usual, create the bridge instance with the required parameters
+
+```
+const bridge = new AsBridge.VLBridge(
+  carto,
+  map,
+  layer,
+  source
+);
+```
+
+Then, you will just have to call the `globalRange` method, like the following:
+
+```
+bridge.globalRange({
+  column: 'gdp',
+  widget: gdpRange
+});
+```
+
+The gdpRange widget will get its range set to the global range of the `gdp` column, and filter the visualization.
+
+As usual, create any other filters if required and call the `build` method.
+
+```
+bridge.build();
+```
+
+### Reference
+
+#### VLBridge.globalRange(options: GlobalRangeOptions) => GlobalRangeFilter
+
+This method receives the following object as options:
+
+```
+GlobalRangeOptions {
+  column: string;
+  widget: HTMLAsRangeSliderElement;
+}
+```
+
+`column` is a string for the visualization column to get the data from.
+`widget` is your as-range-slider HTML element.
+
+This method returns the GlobalRangeFilter instance.
+
+### Widget side effects
+
+When using this filter, several properties will be updated internally, so you should avoid updating them:
+
+- `range`
+- `minValue`
+- `maxValue`


### PR DESCRIPTION
This PR adds a `global` range slider filter to the Bridge. This lets you easily filter a range for number columns using an as-range-slider widget. Underneath it uses globalMax and globalMin, and a `$x > y and $x < z` filter

I mentioned this in passing to @makella @elenatorro and @jorgesancha while demoing the bridge and thought, hey, might as well add it since it's a low hanging fruit.