### PR TITLE
Broken theme example on dev center

### DIFF
--- a/examples/examples.json
+++ b/examples/examples.json
@@ -102,7 +102,7 @@
     {
       "title": "Theming",
       "samples": [{
-        "title": "Custom themes (default, dark, light)",
+        "title": "Custom themes",
         "file": "themes/default.html"
       }]
     },


### PR DESCRIPTION
Fix for the dev center, the theme examples does not render correctly because of parenthesis.