### PR TITLE
Fix as-responsive-content not loading widgets on panels

### DIFF
--- a/packages/components/src/components/as-responsive-content/as-responsive-content.tsx
+++ b/packages/components/src/components/as-responsive-content/as-responsive-content.tsx
@@ -82,14 +82,17 @@ export class ResponsiveContent {
     );
   }
 
-  private setActive(section: ApplicationSection) {
+  private setActive(section: ApplicationSection, redraw: boolean = true) {
     if (section.active) {
       return;
     }
 
     this.disableActiveSection();
     section.enable();
-    redrawChildren(section.element);
+
+    if (redraw) {
+      redrawChildren(section.element);
+    }
 
 
     this.activeSection = section;
@@ -117,7 +120,7 @@ export class ResponsiveContent {
 
     if (sections.length) {
       sections.sort((a, b) => a.order - b.order);
-      this.setActive(sections[0]);
+      this.setActive(sections[0], false);
     }
 
     return sections;


### PR DESCRIPTION
Ever since Airship v1 this has happened and we only recently noticed.

### What's going on?

In order to re-render some widgets that need a parent with actual size, like the histogram or the stacked bar widget, the as-responsive-content widget looks for `as-*` elements each time you switch tabs and calls `forceUpdate`, a stencil method to force a full redraw of the element.

If this method is called too early, the stencil lazy loader has not downloaded the actual element script yet, causing it to fail. 

We noticed that widgets on the panels, _and only on the panels_ were sometimes not rendering. This happens because we set the first element (in tab order) to active, which is where we're doing the force update. Panels are inside of the map element, despite ending on a different tab, so the query locates them too. If you reorder the tabs so that the sidebar is the first one, the sidebar widgets will fail but not the rest.

Since: 
A) Most cases put the map on the first tab (default value, too)
B) We didn't have legends up until a few weeks ago

We never really had widgets on panels combined with the as-responsive-content widget.

The fix is trivial, I'm blocking the first forceUpdate, which is done when querying the child elements of the component.