### PR TITLE
Use getLegendData for opacity

### DIFF
--- a/packages/bridge/src/vl/legends/index.ts
+++ b/packages/bridge/src/vl/legends/index.ts
@@ -5,7 +5,7 @@ import { waitUntilLoaded } from '../utils/layers';
 const FALLBACK_WIDTH = 16;
 const FALLBACK_COLOR = '#000';
 
-function _getDefaultRampValue(ramp) {
+function _getLegendData(ramp) {
   const legendData = ramp.getLegendData();
   const index = Math.floor(legendData.data.length / 2);
   return legendData.data[index].value;
@@ -14,11 +14,11 @@ function _getDefaultRampValue(ramp) {
 function _getColorValue(viz, propName) {
   const prop = viz[propName];
 
-  if (prop.expressionName === 'ramp') {
-    return rgbToHex(_getDefaultRampValue(prop));
+  if (prop.expressionName === 'ramp' || prop.expressionName === 'opacity') {
+    return rgbToHex(_getLegendData(prop));
   }
 
-  if (prop.color || prop.expressionName === 'opacity') {
+  if (prop.color) {
     return rgbToHex(prop.value);
   }
 
@@ -29,7 +29,7 @@ function _getNumberValue(viz, propName, defaultValue?) {
   const prop = viz[propName];
 
   if (prop.expressionName === 'ramp') {
-    return defaultValue || _getDefaultRampValue(prop);
+    return defaultValue || _getLegendData(prop);
   }
 
   if (prop.type === 'number') {
@@ -43,7 +43,7 @@ function _getSymbolValue(viz) {
   const prop = viz.symbol;
 
   if (prop.expressionName === 'ramp') {
-    return _getDefaultRampValue(prop);
+    return _getLegendData(prop);
   }
 
   return prop.value;


### PR DESCRIPTION
Fix https://github.com/CartoDB/carto-vl/issues/1353
![Screenshot 2019-05-24 at 17 42 49](https://user-images.githubusercontent.com/3824953/58340236-a1942b80-7e4b-11e9-8037-b281e4b82bc7.png)

---

Use getLegendData for opacity, which is used in CARTOFrames helpers