### PR TITLE
Fix: unable to select highest value in a dataset [ch58611]

### DIFF
--- a/packages/bridge/src/vl/VLBridge.ts
+++ b/packages/bridge/src/vl/VLBridge.ts
@@ -485,7 +485,10 @@ export default class VLBridge {
 
     // Update the Visualization filter
     this._layer.viz.filter.blendTo(newFilter, 0);
-    this._animation.restart();
+
+    if (this._animation) {
+      this._animation.restart();
+    }
   }
 
   private _combineFilters(filters) {

--- a/packages/bridge/src/vl/histogram/NumericalHistogramFilter.ts
+++ b/packages/bridge/src/vl/histogram/NumericalHistogramFilter.ts
@@ -76,7 +76,7 @@ export class NumericalHistogramFilter extends BaseHistogramFilter<Array<number |
     const min = minN instanceof Date ? `date('${minN.toISOString()}')` : minN;
     const max = maxN instanceof Date ? `date('${maxN.toISOString()}')` : maxN;
 
-    return `(@${this.columnPropName} >= ${min} and @${this.columnPropName} < ${max})`;
+    return `(@${this.columnPropName} >= ${min} and @${this.columnPropName} <= ${max})`;
   }
 
   /**
@@ -158,7 +158,7 @@ export class NumericalHistogramFilter extends BaseHistogramFilter<Array<number |
         }
       }
 
-      const newHistogram = (this._dataLayer.viz.variables[this.name] as VLNumericalHistogram);
+      const newHistogram = this._dataLayer.viz.variables[this.name] as VLNumericalHistogram;
 
       if (!newHistogram) {
         return;


### PR DESCRIPTION
In CARTOframes, it is not possible to select the highest value in a Histogram cause the Numerical Histogram Filter was not including it:

![filter](https://user-images.githubusercontent.com/3824953/74330842-b70f0400-4d92-11ea-9435-e78756b7d52e.gif)

This PR also includes a minor fix to check if an animation exists before it tries to restart it.