### PR TITLE
Add overflow hidden to #map

### DIFF
--- a/packages/styles/src/core/layout/main/map-area/_map-area.scss
+++ b/packages/styles/src/core/layout/main/map-area/_map-area.scss
@@ -9,5 +9,6 @@
   #map {
     z-index: $z-index-0;
     flex: 1;
+    overflow: hidden;
   }
 }


### PR DESCRIPTION
This PR adds `overflow: hidden` to map container so that any element that overflows doesn't cause the page to scroll.