### PR TITLE
feat: Add option `show-clear-button` for histogram and time series widgets

### DIFF
--- a/docs/guides/12-integrating-Vue.md
+++ b/docs/guides/12-integrating-Vue.md
@@ -141,7 +141,7 @@ To mirror the Airship Component, we need to create a new Vue component like this
   <as-category-widget
     heading={heading}
     description={description}
-    show-clear={showClear}
+    show-clear-button={showClearButton}
     defaultBarColor={defaultBarColor}>
   </as-category-widget>
 </template>
@@ -152,7 +152,7 @@ To mirror the Airship Component, we need to create a new Vue component like this
     properties: {
       heading: String,
       description: String,
-      showClear: Boolean,
+      showClearButton: Boolean,
       defaultBarColor: String,
       categories: Object
     },

--- a/examples/bridge/animation-controls/combined-filters.html
+++ b/examples/bridge/animation-controls/combined-filters.html
@@ -42,7 +42,7 @@
           </div>
           <div class="as-box">
             <as-category-widget
-              show-clear>
+              show-clear-button>
             </as-category-widget>
           </div>
         </div>

--- a/examples/bridge/animation-controls/combined-filters.html
+++ b/examples/bridge/animation-controls/combined-filters.html
@@ -1,96 +1,104 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Airship bridge</title>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Airship bridge</title>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
+    <script src="https://libs.cartocdn.com/carto-vl/v1.4/carto-vl.min.js"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
-  <script src="https://libs.cartocdn.com/carto-vl/v1.3/carto-vl.min.js"></script>
+    <link
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css"
+      rel="stylesheet"
+    />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
 
-  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
-  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+    <link rel="stylesheet" href="../../../packages/styles/dist/airship.css" />
+    <script
+      type="module"
+      src="../../../packages/components/dist/airship/airship.esm.js"
+    ></script>
+    <script
+      nomodule=""
+      src="../../../packages/components/dist/airship/airship.js"
+    ></script>
+    <script src="../../../packages/bridge/dist/asbridge.js"></script>
 
-  <link rel="stylesheet" href="../../../packages/styles/dist/airship.css">
-  <script type="module" src="../../../packages/components/dist/airship/airship.esm.js"></script>
-  <script nomodule="" src="../../../packages/components/dist/airship/airship.js"></script>
-  <script src="../../../packages/bridge/dist/asbridge.js"></script>
+    <style>
+      .as-map-footer {
+        max-width: 812px;
+      }
+    </style>
+  </head>
 
-  <style>
-    .as-map-footer {
-      max-width: 812px;
-    }
-  </style>
-</head>
-
-<body class="as-app-body">
-  <div class="as-app">
-    <div class="as-content">
-      <main class="as-main">
-        <div class="as-map-area">
-          <div id="map"></div>
-        </div>
-        <div class="as-map-footer">
-          <div class="as-box">
-            <as-animation-controls-widget
-              animated
-              heading='Animation'
-              description='Try seeking and pausing'>
-            </as-animation-controls-widget>
+  <body class="as-app-body">
+    <div class="as-app">
+      <div class="as-content">
+        <main class="as-main">
+          <div class="as-map-area">
+            <div id="map"></div>
           </div>
-          <div class="as-box">
-            <as-category-widget
-              show-clear-button>
-            </as-category-widget>
+          <div class="as-map-footer">
+            <div class="as-box">
+              <as-animation-controls-widget
+                animated
+                heading="Animation"
+                description="Try seeking and pausing"
+              >
+              </as-animation-controls-widget>
+            </div>
+            <div class="as-box">
+              <as-category-widget show-clear-button> </as-category-widget>
+            </div>
           </div>
-        </div>
-      </main>
+        </main>
+      </div>
     </div>
-  </div>
 
-  <script>
-    const map = new mapboxgl.Map({
-      container: 'map',
-      style: carto.basemaps.darkmatter,
-      center: [-122.327739, 47.615199],
-      zoom: 10
-    });
+    <script>
+      const map = new mapboxgl.Map({
+        container: "map",
+        style: carto.basemaps.darkmatter,
+        center: [-122.327739, 47.615199],
+        zoom: 10,
+      });
 
-    carto.setDefaultAuth({
-      username: 'cartovl',
-      apiKey: 'default_public'
-    });
+      carto.setDefaultAuth({
+        username: "cartovl",
+        apiKey: "default_public",
+      });
 
-    const source = new carto.source.Dataset('seattle_collisions');
-    const viz = new carto.Viz(`
+      const source = new carto.source.Dataset("seattle_collisions");
+      const viz = new carto.Viz(`
       @duration: 30
       strokeWidth: 0
       color: ramp($addrtype, Bold)
       filter: animation($incdate, 30, fade(1, 1))
     `);
 
-    const layer = new carto.Layer('layer', source, viz);
-    const animationControlsWidget = document.querySelector('as-animation-controls-widget');
-    const categoryWidget = document.querySelector('as-category-widget');
+      const layer = new carto.Layer("layer", source, viz);
+      const animationControlsWidget = document.querySelector(
+        "as-animation-controls-widget"
+      );
+      const categoryWidget = document.querySelector("as-category-widget");
 
-    layer.addTo(map, 'watername_ocean');
+      layer.addTo(map, "watername_ocean");
 
-    const bridge = new AsBridge.VLBridge({
-      carto: carto,
-      map: map,
-      layer: layer,
-      source: source
-    });
+      const bridge = new AsBridge.VLBridge({
+        carto: carto,
+        map: map,
+        layer: layer,
+        source: source,
+      });
 
-    bridge.animationControls(animationControlsWidget, 'year');
-    bridge.category(categoryWidget, 'addrtype', {
-      readOnly: false
-    });
+      bridge.animationControls(animationControlsWidget, "year");
+      bridge.category(categoryWidget, "addrtype", {
+        readOnly: false,
+      });
 
-    bridge.build();
-  </script>
-</body>
-
+      bridge.build();
+    </script>
+  </body>
 </html>

--- a/examples/bridge/animation-controls/date-format.html
+++ b/examples/bridge/animation-controls/date-format.html
@@ -1,63 +1,75 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Airship bridge</title>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Airship bridge</title>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
+    <script src="https://libs.cartocdn.com/carto-vl/v1.4/carto-vl.min.js"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
-  <script src="https://libs.cartocdn.com/carto-vl/v1.3/carto-vl.min.js"></script>
+    <link
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css"
+      rel="stylesheet"
+    />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
 
-  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
-  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+    <link rel="stylesheet" href="../../../packages/styles/dist/airship.css" />
+    <script
+      type="module"
+      src="../../../packages/components/dist/airship/airship.esm.js"
+    ></script>
+    <script
+      nomodule=""
+      src="../../../packages/components/dist/airship/airship.js"
+    ></script>
+    <script src="../../../packages/bridge/dist/asbridge.js"></script>
 
-  <link rel="stylesheet" href="../../../packages/styles/dist/airship.css">
-  <script type="module" src="../../../packages/components/dist/airship/airship.esm.js"></script>
-  <script nomodule="" src="../../../packages/components/dist/airship/airship.js"></script>
-  <script src="../../../packages/bridge/dist/asbridge.js"></script>
+    <style>
+      .as-map-footer {
+        max-width: 812px;
+      }
+    </style>
+  </head>
 
-  <style>
-    .as-map-footer {
-      max-width: 812px;
-    }
-  </style>
-</head>
-
-<body class="as-app-body">
-  <div class="as-app">
-    <div class="as-content">
-      <main class="as-main">
-        <div class="as-map-area">
-          <div id="map"></div>
-        </div>
-        <div class="as-map-footer">
-          <div class="as-box">
-            <as-animation-controls-widget animated heading='Animation' description='Try seeking and pausing'>
-            </as-animation-controls-widget>
+  <body class="as-app-body">
+    <div class="as-app">
+      <div class="as-content">
+        <main class="as-main">
+          <div class="as-map-area">
+            <div id="map"></div>
           </div>
-        </div>
-      </main>
+          <div class="as-map-footer">
+            <div class="as-box">
+              <as-animation-controls-widget
+                animated
+                heading="Animation"
+                description="Try seeking and pausing"
+              >
+              </as-animation-controls-widget>
+            </div>
+          </div>
+        </main>
+      </div>
     </div>
-  </div>
-  <script>
-    const map = new mapboxgl.Map({
-      container: 'map',
-      style: carto.basemaps.darkmatter,
-      center: [-74.0032059, 40.7482066],
-      zoom: 12,
-    });
+    <script>
+      const map = new mapboxgl.Map({
+        container: "map",
+        style: carto.basemaps.darkmatter,
+        center: [-74.0032059, 40.7482066],
+        zoom: 12,
+      });
 
-    carto.setDefaultAuth({
-      apiKey: 'default_public',
-      username: 'cartovl'
-    });
+      carto.setDefaultAuth({
+        apiKey: "default_public",
+        username: "cartovl",
+      });
 
-    const s = carto.expressions;
-    const source = new carto.source.Dataset('taxi_50k');
+      const s = carto.expressions;
+      const source = new carto.source.Dataset("taxi_50k");
 
-    const viz = new carto.Viz(`
+      const viz = new carto.Viz(`
       @hour: clusterTime($tpep_pickup_datetime, 'hour', 'America/New_York')
 
       width: 10
@@ -71,21 +83,20 @@
       @minhour: globalMin(@hour)
     `);
 
-    const layer = new carto.Layer('layer', source, viz);
-    layer.addTo(map);
+      const layer = new carto.Layer("layer", source, viz);
+      layer.addTo(map);
 
-    const timeWidget = document.querySelector('as-animation-controls-widget');
+      const timeWidget = document.querySelector("as-animation-controls-widget");
 
-    const bridge = new AsBridge.VLBridge({
-      carto: carto,
-      map: map,
-      layer: layer,
-      source: source
-    });
+      const bridge = new AsBridge.VLBridge({
+        carto: carto,
+        map: map,
+        layer: layer,
+        source: source,
+      });
 
-    bridge.animationControls('as-animation-controls-widget', 'hour');
-    bridge.build();
-  </script>
-</body>
-
+      bridge.animationControls("as-animation-controls-widget", "hour");
+      bridge.build();
+    </script>
+  </body>
 </html>

--- a/examples/bridge/animation-controls/default.html
+++ b/examples/bridge/animation-controls/default.html
@@ -1,85 +1,96 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Airship bridge</title>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Airship bridge</title>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
+    <script src="https://libs.cartocdn.com/carto-vl/v1.4/carto-vl.min.js"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
-  <script src="https://libs.cartocdn.com/carto-vl/v1.3/carto-vl.min.js"></script>
+    <link
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css"
+      rel="stylesheet"
+    />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
 
-  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
-  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+    <link rel="stylesheet" href="../../../packages/styles/dist/airship.css" />
+    <script
+      type="module"
+      src="../../../packages/components/dist/airship/airship.esm.js"
+    ></script>
+    <script
+      nomodule=""
+      src="../../../packages/components/dist/airship/airship.js"
+    ></script>
+    <script src="../../../packages/bridge/dist/asbridge.js"></script>
 
-  <link rel="stylesheet" href="../../../packages/styles/dist/airship.css">
-  <script type="module" src="../../../packages/components/dist/airship/airship.esm.js"></script>
-  <script nomodule="" src="../../../packages/components/dist/airship/airship.js"></script>
-  <script src="../../../packages/bridge/dist/asbridge.js"></script>
+    <style>
+      .as-map-footer {
+        max-width: 812px;
+      }
+    </style>
+  </head>
 
-  <style>
-    .as-map-footer {
-      max-width: 812px;
-    }
-  </style>
-</head>
-
-<body class="as-app-body">
-  <div class="as-app">
-    <div class="as-content">
-      <main class="as-main">
-        <div class="as-map-area">
-          <div id="map"></div>
-        </div>
-        <div class="as-map-footer">
-          <div class="as-box">
-            <as-animation-controls-widget
-              animated
-              heading='Animation'
-              description='Try seeking and pausing'
-            >
-            </as-animation-controls-widget>
+  <body class="as-app-body">
+    <div class="as-app">
+      <div class="as-content">
+        <main class="as-main">
+          <div class="as-map-area">
+            <div id="map"></div>
           </div>
-        </div>
-      </main>
+          <div class="as-map-footer">
+            <div class="as-box">
+              <as-animation-controls-widget
+                animated
+                heading="Animation"
+                description="Try seeking and pausing"
+              >
+              </as-animation-controls-widget>
+            </div>
+          </div>
+        </main>
+      </div>
     </div>
-  </div>
 
-  <script>
-    const map = new mapboxgl.Map({
-      container: 'map',
-      style: carto.basemaps.darkmatter,
-      center: [-4.77, 37.88],
-      zoom: 12
-    });
+    <script>
+      const map = new mapboxgl.Map({
+        container: "map",
+        style: carto.basemaps.darkmatter,
+        center: [-4.77, 37.88],
+        zoom: 12,
+      });
 
-    carto.setDefaultAuth({
-      username: 'roman-carto',
-      apiKey: 'default_public'
-    });
+      carto.setDefaultAuth({
+        username: "roman-carto",
+        apiKey: "default_public",
+      });
 
-    const source = new carto.source.SQL(`select * from cordoba_catastro_simple where year > 1900 and year < 2018`);
-    const viz = new carto.Viz(`
+      const source = new carto.source.SQL(
+        `select * from cordoba_catastro_simple where year > 1900 and year < 2018`
+      );
+      const viz = new carto.Viz(`
       @duration: 30
       strokeWidth: 0
     `);
 
-    const vizLayer = new carto.Layer('layer', source, viz);
-    const animationControlsWidget = document.querySelector('as-animation-controls-widget');
+      const vizLayer = new carto.Layer("layer", source, viz);
+      const animationControlsWidget = document.querySelector(
+        "as-animation-controls-widget"
+      );
 
-    vizLayer.addTo(map, 'watername_ocean');
+      vizLayer.addTo(map, "watername_ocean");
 
-    const bridge = new AsBridge.VLBridge({
-      carto: carto,
-      map: map,
-      layer: vizLayer,
-      source: source
-    });
+      const bridge = new AsBridge.VLBridge({
+        carto: carto,
+        map: map,
+        layer: vizLayer,
+        source: source,
+      });
 
-    bridge.animationControls(animationControlsWidget, 'year');
-    bridge.build();
-  </script>
-</body>
-
+      bridge.animationControls(animationControlsWidget, "year");
+      bridge.build();
+    </script>
+  </body>
 </html>

--- a/examples/bridge/animation-controls/property.html
+++ b/examples/bridge/animation-controls/property.html
@@ -1,85 +1,95 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Airship bridge</title>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Airship bridge</title>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
+    <script src="https://libs.cartocdn.com/carto-vl/v1.4/carto-vl.min.js"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
-  <script src="https://libs.cartocdn.com/carto-vl/v1.3/carto-vl.min.js"></script>
+    <link
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css"
+      rel="stylesheet"
+    />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
 
-  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
-  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+    <link rel="stylesheet" href="../../../packages/styles/dist/airship.css" />
+    <script
+      type="module"
+      src="../../../packages/components/dist/airship/airship.esm.js"
+    ></script>
+    <script
+      nomodule=""
+      src="../../../packages/components/dist/airship/airship.js"
+    ></script>
+    <script src="../../../packages/bridge/dist/asbridge.js"></script>
 
-  <link rel="stylesheet" href="../../../packages/styles/dist/airship.css">
-  <script type="module" src="../../../packages/components/dist/airship/airship.esm.js"></script>
-  <script nomodule="" src="../../../packages/components/dist/airship/airship.js"></script>
-  <script src="../../../packages/bridge/dist/asbridge.js"></script>
+    <style>
+      .as-map-footer {
+        max-width: 812px;
+      }
+    </style>
+  </head>
 
-  <style>
-    .as-map-footer {
-      max-width: 812px;
-    }
-  </style>
-</head>
-
-<body class="as-app-body">
-  <div class="as-app">
-    <div class="as-content">
-      <main class="as-main">
-        <div class="as-map-area">
-          <div id="map"></div>
-        </div>
-        <div class="as-map-footer">
-          <div class="as-box">
-            <as-animation-controls-widget
-              animated
-              heading='Animation'
-              description='Try seeking and pausing'
-            >
-            </as-animation-controls-widget>
+  <body class="as-app-body">
+    <div class="as-app">
+      <div class="as-content">
+        <main class="as-main">
+          <div class="as-map-area">
+            <div id="map"></div>
           </div>
-        </div>
-      </main>
+          <div class="as-map-footer">
+            <div class="as-box">
+              <as-animation-controls-widget
+                animated
+                heading="Animation"
+                description="Try seeking and pausing"
+              >
+              </as-animation-controls-widget>
+            </div>
+          </div>
+        </main>
+      </div>
     </div>
-  </div>
 
-  <script>
-    const map = new mapboxgl.Map({
-      container: 'map',
-      style: carto.basemaps.darkmatter,
-      center: [-122.30571212980425, 47.6181],
-      zoom: 10
-    });
+    <script>
+      const map = new mapboxgl.Map({
+        container: "map",
+        style: carto.basemaps.darkmatter,
+        center: [-122.30571212980425, 47.6181],
+        zoom: 10,
+      });
 
-    carto.setDefaultAuth({
-      username: 'cartovl',
-      apiKey: 'default_public'
-    });
+      carto.setDefaultAuth({
+        username: "cartovl",
+        apiKey: "default_public",
+      });
 
-    const source = new carto.source.Dataset('seattle_collisions');
-    const viz = new carto.Viz(`
+      const source = new carto.source.Dataset("seattle_collisions");
+      const viz = new carto.Viz(`
       color: ramp($addrtype, Bold)
       @myVariable: animation(linear($incdate), 20,fade(1, 1)) * ramp(linear($personcount, 2, 5), [5, 20])
       strokeWidth: 0
     `);
 
-    const vizLayer = new carto.Layer('layer', source, viz);
+      const vizLayer = new carto.Layer("layer", source, viz);
 
-    vizLayer.addTo(map, 'watername_ocean');
+      vizLayer.addTo(map, "watername_ocean");
 
-    const bridge = new AsBridge.VLBridge({
-      carto: carto,
-      map: map,
-      layer: vizLayer,
-      source: source
-    });
+      const bridge = new AsBridge.VLBridge({
+        carto: carto,
+        map: map,
+        layer: vizLayer,
+        source: source,
+      });
 
-    bridge.animationControls('as-animation-controls-widget', 'incdate', { variableName: 'myVariable', propertyName: 'width' });
-    bridge.build();
-  </script>
-</body>
-
+      bridge.animationControls("as-animation-controls-widget", "incdate", {
+        variableName: "myVariable",
+        propertyName: "width",
+      });
+      bridge.build();
+    </script>
+  </body>
 </html>

--- a/examples/bridge/animation-controls/simple.html
+++ b/examples/bridge/animation-controls/simple.html
@@ -1,85 +1,94 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Airship bridge</title>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Airship bridge</title>
+    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
+    <script src="https://libs.cartocdn.com/carto-vl/v1.4/carto-vl.min.js"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.11/lodash.min.js"></script>
-  <script src="https://libs.cartocdn.com/carto-vl/v1.3/carto-vl.min.js"></script>
+    <link
+      href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css"
+      rel="stylesheet"
+    />
+    <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
 
-  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.css" rel="stylesheet" />
-  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.52.0/mapbox-gl.js"></script>
+    <link rel="stylesheet" href="../../../packages/styles/dist/airship.css" />
+    <script
+      type="module"
+      src="../../../packages/components/dist/airship/airship.esm.js"
+    ></script>
+    <script
+      nomodule=""
+      src="../../../packages/components/dist/airship/airship.js"
+    ></script>
+    <script src="../../../packages/bridge/dist/asbridge.js"></script>
 
-  <link rel="stylesheet" href="../../../packages/styles/dist/airship.css">
-  <script type="module" src="../../../packages/components/dist/airship/airship.esm.js"></script>
-  <script nomodule="" src="../../../packages/components/dist/airship/airship.js"></script>
-  <script src="../../../packages/bridge/dist/asbridge.js"></script>
+    <style>
+      .as-map-footer {
+        max-width: 812px;
+      }
+    </style>
+  </head>
 
-  <style>
-    .as-map-footer {
-      max-width: 812px;
-    }
-  </style>
-</head>
-
-<body class="as-app-body">
-  <div class="as-app">
-    <div class="as-content">
-      <main class="as-main">
-        <div class="as-map-area">
-          <div id="map"></div>
-        </div>
-        <div class="as-map-footer">
-          <div class="as-box">
-            <as-animation-controls-widget
-              animated
-              heading='Animation'
-              description='Try seeking and pausing'
-            >
-            </as-animation-controls-widget>
+  <body class="as-app-body">
+    <div class="as-app">
+      <div class="as-content">
+        <main class="as-main">
+          <div class="as-map-area">
+            <div id="map"></div>
           </div>
-        </div>
-      </main>
+          <div class="as-map-footer">
+            <div class="as-box">
+              <as-animation-controls-widget
+                animated
+                heading="Animation"
+                description="Try seeking and pausing"
+              >
+              </as-animation-controls-widget>
+            </div>
+          </div>
+        </main>
+      </div>
     </div>
-  </div>
 
-  <script>
-    const map = new mapboxgl.Map({
-      container: 'map',
-      style: carto.basemaps.darkmatter,
-      center: [-4.77, 37.88],
-      zoom: 12
-    });
+    <script>
+      const map = new mapboxgl.Map({
+        container: "map",
+        style: carto.basemaps.darkmatter,
+        center: [-4.77, 37.88],
+        zoom: 12,
+      });
 
-    carto.setDefaultAuth({
-      username: 'roman-carto',
-      apiKey: 'default_public'
-    });
+      carto.setDefaultAuth({
+        username: "roman-carto",
+        apiKey: "default_public",
+      });
 
-    const source = new carto.source.SQL(`select * from cordoba_catastro_simple where year > 1900 and year < 2018`);
-    const viz = new carto.Viz(`
+      const source = new carto.source.SQL(
+        `select * from cordoba_catastro_simple where year > 1900 and year < 2018`
+      );
+      const viz = new carto.Viz(`
       @duration: 30
       filter: animation(linear($year, 1900, 2017), @duration, fade(0.1, ${Number.MAX_SAFE_INTEGER}))
       strokeWidth: 0
     `);
 
-    const vizLayer = new carto.Layer('layer', source, viz);
+      const vizLayer = new carto.Layer("layer", source, viz);
 
-    vizLayer.addTo(map, 'watername_ocean');
+      vizLayer.addTo(map, "watername_ocean");
 
-    const bridge = new AsBridge.VLBridge({
-      carto: carto,
-      map: map,
-      layer: vizLayer,
-      source: source
-    });
+      const bridge = new AsBridge.VLBridge({
+        carto: carto,
+        map: map,
+        layer: vizLayer,
+        source: source,
+      });
 
-    bridge.animationControls('as-animation-controls-widget', 'year');
-    bridge.build();
-  </script>
-</body>
-
+      bridge.animationControls("as-animation-controls-widget", "year");
+      bridge.build();
+    </script>
+  </body>
 </html>

--- a/examples/bridge/category/category.html
+++ b/examples/bridge/category/category.html
@@ -35,14 +35,14 @@
         <div class="as-map-footer">
           <div class="as-box">
             <as-histogram-widget
-              show-clear
+              show-clear-button
               id="typeHist"
             >
             </as-histogram-widget>
           </div>
           <div class="as-box">
             <as-category-widget
-              show-clear
+              show-clear-button
               id="typeCat"
             >
             </as-category-widget>

--- a/examples/bridge/histogram/simple.html
+++ b/examples/bridge/histogram/simple.html
@@ -35,7 +35,7 @@
         <div class="as-map-footer">
           <div class="as-box">
             <as-histogram-widget
-              show-clear
+              show-clear-button
               id="typeHist"
               heading="Location"
             >
@@ -43,7 +43,7 @@
           </div>
           <div class="as-box">
             <as-histogram-widget
-              show-clear
+              show-clear-button
               id="scaleHist"
               heading="Scalerank"
             >

--- a/examples/bridge/time-series/combined-category.html
+++ b/examples/bridge/time-series/combined-category.html
@@ -42,7 +42,7 @@
           </div>
           <div class="as-box">
             <as-category-widget
-              show-clear>
+              show-clear-button>
             </as-category-widget>
           </div>
         </div>

--- a/examples/components/as-histogram-widget/background-data.html
+++ b/examples/components/as-histogram-widget/background-data.html
@@ -15,7 +15,7 @@
       <as-histogram-widget
         heading="Title"
         show-header
-        show-clear>
+        show-clear-button>
       </as-histogram-widget>
     </div>
 

--- a/examples/components/as-histogram-widget/categorical-data.html
+++ b/examples/components/as-histogram-widget/categorical-data.html
@@ -15,7 +15,7 @@
       <as-histogram-widget
         heading="Title"
         show-header
-        show-clear>
+        show-clear-button>
       </as-histogram-widget>
     </div>
 

--- a/examples/components/as-histogram-widget/events.html
+++ b/examples/components/as-histogram-widget/events.html
@@ -14,7 +14,7 @@
     <div style="width: 250px;">
       <as-histogram-widget
         show-header="false"
-        show-clear>
+        show-clear-button>
       </as-histogram-widget>
     </div>
     <p id="selection">Nothing selected</p>
@@ -31,7 +31,7 @@
       histogramWidget.tooltipFormatter = function (data) {
         return histogramWidget.defaultFormatter(data).then((formatted) => {
           formatted[1] = `${formatted[1]} kg`;
-  
+
           return formatted;
         });
       };

--- a/examples/components/as-histogram-widget/interaction-disabled.html
+++ b/examples/components/as-histogram-widget/interaction-disabled.html
@@ -16,7 +16,7 @@
         heading="Title"
         description="Description"
         show-header
-        show-clear
+        show-clear-button
         disable-interactivity>
       </as-histogram-widget>
     </div>

--- a/examples/components/as-histogram-widget/multiline-tooltip.html
+++ b/examples/components/as-histogram-widget/multiline-tooltip.html
@@ -14,7 +14,7 @@
     <div style="width: 250px;">
       <as-histogram-widget
         show-header="false"
-        show-clear>
+        show-clear-button>
       </as-histogram-widget>
     </div>
     <p id="selection">Nothing selected</p>

--- a/examples/components/as-histogram-widget/simple.html
+++ b/examples/components/as-histogram-widget/simple.html
@@ -16,7 +16,7 @@
         heading="Title"
         description="Description"
         show-header
-        show-clear>
+        show-clear-button>
       </as-histogram-widget>
     </div>
     <script>

--- a/examples/components/as-time-series-widget/animation.html
+++ b/examples/components/as-time-series-widget/animation.html
@@ -29,10 +29,10 @@
 <body>
   <as-time-series-widget
     animated
-    x-label="Time" 
+    x-label="Time"
     y-label="Overall world coolness"
     responsive
-    show-clear
+    show-clear-button
     heading="World coolness evolution"
     time-format="%x"
   >
@@ -79,7 +79,7 @@
       }
 
       progress = Math.min(progress + 20, 100);
-      
+
       timeSeriesWidget.progress = progress;
       timeSeriesWidget.playing = !paused;
 
@@ -105,7 +105,7 @@
 
     timeSeriesWidget.tooltipFormatter = (data) => {
       return Promise.all(
-        [ 
+        [
           timeSeriesWidget.xFormatter(data.start),
           timeSeriesWidget.xFormatter(data.end),
           timeSeriesWidget.defaultFormatter(data)

--- a/examples/components/as-time-series-widget/format.html
+++ b/examples/components/as-time-series-widget/format.html
@@ -94,10 +94,10 @@
       time-format accepts these formats specifiers: https://github.com/d3/d3-time-format#locale_format
     -->
     <as-time-series-widget
-      x-label="Time" 
+      x-label="Time"
       y-label="Overall world coolness"
       responsive
-      show-clear
+      show-clear-button
       heading="World coolness evolution"
       time-format="%x"
     >

--- a/examples/components/as-time-series-widget/simple-dates.html
+++ b/examples/components/as-time-series-widget/simple-dates.html
@@ -28,10 +28,10 @@
 
 <body>
   <as-time-series-widget
-    x-label="Time" 
+    x-label="Time"
     y-label="Overall world coolness"
     responsive
-    show-clear
+    show-clear-button
     heading="World coolness evolution"
   >
   </as-time-series-widget>

--- a/examples/components/as-time-series-widget/simple.html
+++ b/examples/components/as-time-series-widget/simple.html
@@ -28,10 +28,10 @@
 
 <body>
   <as-time-series-widget
-    x-label="Time" 
+    x-label="Time"
     y-label="Overall world coolness"
     responsive
-    show-clear
+    show-clear-button
     heading="World coolness evolution"
   >
   </as-time-series-widget>

--- a/examples/css-variables/index.html
+++ b/examples/css-variables/index.html
@@ -115,7 +115,7 @@
           <as-stacked-bar-widget id="widget-0" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
         </div>
         <div class="as-box">
-          <as-histogram-widget heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          <as-histogram-widget heading="Title" description="Description" show-header show-clear-button></as-histogram-widget>
         </div>
         <script>
           const widget0 = document.querySelector('as-stacked-bar-widget');

--- a/examples/themes/dark.html
+++ b/examples/themes/dark.html
@@ -428,7 +428,7 @@
           <as-stacked-bar-widget id="widget-0" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
         </div>
         <div class="as-box">
-          <as-histogram-widget heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          <as-histogram-widget heading="Title" description="Description" show-header show-clear-button></as-histogram-widget>
         </div>
       </footer>
     </main>

--- a/examples/themes/default.html
+++ b/examples/themes/default.html
@@ -387,7 +387,7 @@
           <as-stacked-bar-widget id="widget-0" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
         </div>
         <div class="as-box">
-          <as-histogram-widget heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          <as-histogram-widget heading="Title" description="Description" show-header show-clear-button></as-histogram-widget>
         </div>
       </footer>
     </main>

--- a/examples/themes/light.html
+++ b/examples/themes/light.html
@@ -439,7 +439,7 @@
           <as-stacked-bar-widget id="widget-0" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
         </div>
         <div class="as-box">
-          <as-histogram-widget heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          <as-histogram-widget heading="Title" description="Description" show-header show-clear-button></as-histogram-widget>
         </div>
       </footer>
     </main>

--- a/packages/bridge/examples/airports.html
+++ b/packages/bridge/examples/airports.html
@@ -31,7 +31,7 @@
                 <div class="as-map-footer">
                   <div class="as-box">
                     <as-histogram-widget
-                      show-clear
+                      show-clear-button
                       id="typeHist"
                       heading="Type"
                     >
@@ -39,7 +39,7 @@
                   </div>
                   <div class="as-box">
                     <as-histogram-widget
-                      show-clear
+                      show-clear-button
                       id="scaleHist"
                       heading="Scalerank"
                     >
@@ -48,7 +48,7 @@
                   <div class="as-box">
                     <as-category-widget
                       style="height: 80%;"
-                      show-clear
+                      show-clear-button
                       id="typeCat"
                       heading="Type"
                     >
@@ -57,7 +57,7 @@
                   </div>
                   <div class="as-box">
                     <as-histogram-widget
-                      show-clear
+                      show-clear-button
                       id="lonCat"
                       heading="Longitude"
                     >

--- a/packages/bridge/examples/cordoba.html
+++ b/packages/bridge/examples/cordoba.html
@@ -40,7 +40,7 @@
                   </div>
                   <div class="as-box">
                     <as-histogram-widget
-                      show-clear
+                      show-clear-button
                       id="year"
                       heading="Year"
                       description='in which building was registered'

--- a/packages/bridge/examples/range.html
+++ b/packages/bridge/examples/range.html
@@ -47,7 +47,7 @@
                 </div>
                 <div class="as-box">
                   <as-histogram-widget
-                    show-clear
+                    show-clear-button
                     id="typeHist"
                     heading="Type"
                   >

--- a/packages/bridge/src/vl/histogram/BaseHistogramFilter.ts
+++ b/packages/bridge/src/vl/histogram/BaseHistogramFilter.ts
@@ -51,7 +51,7 @@ export abstract class BaseHistogramFilter<T> extends BaseFilter {
     this._totals = showTotals;
 
     this._widget.disableInteractivity = readOnly;
-    this._widget.showClear = !readOnly;
+    this._widget.showClearButton = !readOnly;
 
     this._inputExpression = inputExpression;
 

--- a/packages/bridge/src/vl/histogram/README.md
+++ b/packages/bridge/src/vl/histogram/README.md
@@ -107,4 +107,4 @@ The following properties of the histogram will be modified internally, so modify
 - `backgroundData`
 - `data`
 - `disableInteractivity`
-- `showClear`
+- `showClearButton`

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -391,11 +391,18 @@ export namespace Components {
     */
     'setSelection': (values: number[], emit?: boolean) => Promise<void>;
     /**
+    * Deprecated, use showClearButton instead. Display a clear button that clears the histogram selection.
+    * @type {boolean}
+    * @memberof HistogramWidget
+    * @deprecated
+    */
+    'showClear': boolean;
+    /**
     * Display a clear button that clears the histogram selection.
     * @type {boolean}
     * @memberof HistogramWidget
     */
-    'showClear': boolean;
+    'showClearButton': boolean;
     /**
     * Toggles displaying title and description
     * @type {boolean}
@@ -908,11 +915,18 @@ export namespace Components {
     */
     'setSelection': (values: number[]) => Promise<void>;
     /**
+    * Deprecated, use showClearButton instead. Display a clear button that clears the histogram selection.
+    * @type {boolean}
+    * @memberof HistogramWidget
+    * @deprecated
+    */
+    'showClear': boolean;
+    /**
     * Display a clear button that clears the histogram selection.
     * @type {boolean}
     * @memberof HistogramWidget
     */
-    'showClear': boolean;
+    'showClearButton': boolean;
     /**
     * Toggles displaying title and description
     * @type {boolean}
@@ -1781,11 +1795,18 @@ declare namespace LocalJSX {
     */
     'selectedFormatter'?: (value: number[]) => string;
     /**
+    * Deprecated, use showClearButton instead. Display a clear button that clears the histogram selection.
+    * @type {boolean}
+    * @memberof HistogramWidget
+    * @deprecated
+    */
+    'showClear'?: boolean;
+    /**
     * Display a clear button that clears the histogram selection.
     * @type {boolean}
     * @memberof HistogramWidget
     */
-    'showClear'?: boolean;
+    'showClearButton'?: boolean;
     /**
     * Toggles displaying title and description
     * @type {boolean}
@@ -2310,11 +2331,18 @@ declare namespace LocalJSX {
     */
     'responsive'?: boolean;
     /**
+    * Deprecated, use showClearButton instead. Display a clear button that clears the histogram selection.
+    * @type {boolean}
+    * @memberof HistogramWidget
+    * @deprecated
+    */
+    'showClear'?: boolean;
+    /**
     * Display a clear button that clears the histogram selection.
     * @type {boolean}
     * @memberof HistogramWidget
     */
-    'showClear'?: boolean;
+    'showClearButton'?: boolean;
     /**
     * Toggles displaying title and description
     * @type {boolean}

--- a/packages/components/src/components/as-histogram-widget/README.md
+++ b/packages/components/src/components/as-histogram-widget/README.md
@@ -176,21 +176,6 @@ lang: javascript
 histogramWidget.heading = 'Business Volume';
 ```
 
-#### **showClear (deprecated)**: boolean = false
-Deprected: see `showClearButton`.
-If truthy, it'll show a button to clear the histogram selection. Default value is `false`.
-
-```code
-lang: html
----
-<as-histogram-widget show-clear-button></as-histogram-widget>
-```
-
-```code
-lang: javascript
----
-histogram.showClear = true;
-
 #### **showClearButton**: boolean = false
 If truthy, it'll show a button to clear the histogram selection. Default value is `false`.
 

--- a/packages/components/src/components/as-histogram-widget/README.md
+++ b/packages/components/src/components/as-histogram-widget/README.md
@@ -18,7 +18,7 @@ showSource: false
   heading="Title"
   description="Description"
   show-header
-  show-clear>
+  show-clear-button>
 </as-histogram-widget>
 
 <script>
@@ -176,19 +176,34 @@ lang: javascript
 histogramWidget.heading = 'Business Volume';
 ```
 
-#### **showClear**: boolean = false
+#### **showClear (deprecated)**: boolean = false
+Deprected: see `showClearButton`.
 If truthy, it'll show a button to clear the histogram selection. Default value is `false`.
 
 ```code
 lang: html
 ---
-<as-histogram-widget show-clear></as-histogram-widget>
+<as-histogram-widget show-clear-button></as-histogram-widget>
 ```
 
 ```code
 lang: javascript
 ---
 histogram.showClear = true;
+
+#### **showClearButton**: boolean = false
+If truthy, it'll show a button to clear the histogram selection. Default value is `false`.
+
+```code
+lang: html
+---
+<as-histogram-widget show-clear-button></as-histogram-widget>
+```
+
+```code
+lang: javascript
+---
+histogram.showClearButton = true;
 ```
 
 #### **clearText**: string = 'Clear selection'
@@ -511,7 +526,7 @@ showSource: false
 ---
 <as-histogram-widget
   show-header="false"
-  show-clear>
+  show-clear-button>
 </as-histogram-widget>
 <p id="selection">Nothing selected</p>
 <script>
@@ -557,7 +572,7 @@ showSource: false
   heading="Title"
   description="Description"
   show-header
-  show-clear>
+  show-clear-button>
 </as-histogram-widget>
 
 <script>

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget-colors.html
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget-colors.html
@@ -13,7 +13,7 @@
   <body>
     <div style="width: 250px;">
       <as-histogram-widget
-        show-clear
+        show-clear-button
         heading="Business Volume"
         description="Description">
       </as-histogram-widget>

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget-dev.html
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget-dev.html
@@ -14,7 +14,7 @@
     <div style="width: 250px;">
       <as-histogram-widget
         show-header
-        show-clear
+        show-clear-button
         heading="Business Volume"
         description="Description">
       </as-histogram-widget>

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget-labels.html
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget-labels.html
@@ -19,7 +19,7 @@
   <body>
     <div style="width: 300px;">
       <as-histogram-widget
-        show-clear
+        show-clear-button
         disable-interactivity
         heading="Business Volume"
         description="Description"

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.e2e.ts
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.e2e.ts
@@ -55,9 +55,34 @@ describe('as-histogram-widget', () => {
       expect(actual).toBeFalsy();
     });
 
+    it('should never render clear button when the showClearButton attribute is false', async () => {
+      const element: E2EElement = await page.find('as-histogram-widget');
+      element.setProperty('showClearButton', false);
+      element.setProperty('data', histogramData);
+      // It only shows if there's a selection
+      element.callMethod('setSelection', [0, 10]);
+      await page.waitForChanges();
+
+      const actual = await page.find('.as-widget-selection__clear');
+
+      expect(actual).toBeFalsy();
+    });
+
     it('should not render the clear button disabled if no selection is present', async () => {
       const element: E2EElement = await page.find('as-histogram-widget');
       element.setProperty('showClear', true);
+      element.setProperty('data', histogramData);
+      element.callMethod('setSelection', [0, 10]);
+      await page.waitForChanges();
+
+      const actual = await page.find('.as-widget-selection__clear');
+
+      expect(actual).not.toBeFalsy();
+    });
+
+    it('should not render the clear button disabled if no selection is present with showClearButton', async () => {
+      const element: E2EElement = await page.find('as-histogram-widget');
+      element.setProperty('showClearButton', true);
       element.setProperty('data', histogramData);
       element.callMethod('setSelection', [0, 10]);
       await page.waitForChanges();
@@ -79,9 +104,34 @@ describe('as-histogram-widget', () => {
       expect(actual).not.toBeFalsy();
     });
 
+    it('should render clear button enabled if there is a selection with showClearButton', async () => {
+      const element: E2EElement = await page.find('as-histogram-widget');
+      element.setProperty('showClearButton', true);
+      element.setProperty('data', histogramData);
+      element.callMethod('setSelection', [0, 10]);
+      await page.waitForChanges();
+
+      const actual = await page.find('.as-widget-selection__clear');
+
+      expect(actual).not.toBeFalsy();
+    });
+
     it('should render custom clear button text', async () => {
       const element: E2EElement = await page.find('as-histogram-widget');
       element.setProperty('showClear', true);
+      element.setProperty('clearText', 'Radio Gaga');
+      element.setProperty('data', histogramData);
+      element.callMethod('setSelection', [0, 10]);
+      await page.waitForChanges();
+
+      const actual = await page.find('.as-widget-selection__clear');
+
+      expect(actual.innerText).toEqual('Radio Gaga');
+    });
+
+    it('should render custom clear button text with showClearButton', async () => {
+      const element: E2EElement = await page.find('as-histogram-widget');
+      element.setProperty('showClearButton', true);
       element.setProperty('clearText', 'Radio Gaga');
       element.setProperty('data', histogramData);
       element.callMethod('setSelection', [0, 10]);

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.html
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.html
@@ -23,7 +23,7 @@
 
   <body>
     <as-histogram-widget
-        show-clear
+        show-clear-button
         heading="Business Volume"
         description="Description">
     </as-histogram-widget>

--- a/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
+++ b/packages/components/src/components/as-histogram-widget/as-histogram-widget.tsx
@@ -78,12 +78,22 @@ export class HistogramWidget {
   @Prop() public showHeader: boolean = true;
 
   /**
+   * Deprecated, use showClearButton instead.
+   * Display a clear button that clears the histogram selection.
+   *
+   * @type {boolean}
+   * @memberof HistogramWidget
+   * @deprecated
+   */
+  @Prop() public showClear: boolean;
+
+  /**
    * Display a clear button that clears the histogram selection.
    *
    * @type {boolean}
    * @memberof HistogramWidget
    */
-  @Prop() public showClear: boolean;
+  @Prop() public showClearButton: boolean;
 
   /**
    * Disables selection brushes and events for the widget
@@ -553,7 +563,7 @@ export class HistogramWidget {
   }
 
   private _renderSelection() {
-    if (this._isLoading() || this._isEmpty() || this.error || !this.showClear) {
+    if (this._isLoading() || this._isEmpty() || this.error || !(this.showClear || this.showClearButton)) {
       return '';
     }
 

--- a/packages/components/src/components/as-histogram-widget/background-data-categorical.html
+++ b/packages/components/src/components/as-histogram-widget/background-data-categorical.html
@@ -27,7 +27,7 @@
 </head>
 
 <body>
-  <as-histogram-widget x-label="x-axis" y-label="y-axis" responsive show-clear heading="Business Volume" description="Description">
+  <as-histogram-widget x-label="x-axis" y-label="y-axis" responsive show-clear-button heading="Business Volume" description="Description">
   </as-histogram-widget>
 
   <script>
@@ -53,7 +53,7 @@
         value: 4000
       },
     ];
-    
+
     let dataSource = histogramWidget.data = data;
     histogramWidget.backgroundData = data.map((value) => ({
       ...value,
@@ -71,7 +71,7 @@
       const newData = histogramWidget.data
         .filter((d) => selection.indexOf(d.category) !== -1)
         .map(d => d);
-      
+
       histogramWidget.data = newData;
     });
   </script>

--- a/packages/components/src/components/as-histogram-widget/background-data.html
+++ b/packages/components/src/components/as-histogram-widget/background-data.html
@@ -30,7 +30,7 @@
   <button class="as-btn as-btn--primary js-back">Change background data to range: [0 - 500]</button>
   <button class="as-btn as-btn--primary js-data">Set data to range [0 - 500]</button>
   <button class="as-btn as-btn--primary js-wrongBack">Set background data to [-10, currentMaxRange]</button>
-  <as-histogram-widget x-label="x-axis" y-label="y-axis" responsive show-clear heading="Business Volume" description="Description">
+  <as-histogram-widget x-label="x-axis" y-label="y-axis" responsive show-clear-button heading="Business Volume" description="Description">
   </as-histogram-widget>
 
   <script>
@@ -61,7 +61,7 @@
         value: 2000
       },
     ];
-    
+
     let dataSource = histogramWidget.data = data;
     histogramWidget.backgroundData = data.map((value) => ({
       ...value,

--- a/packages/components/src/components/as-histogram-widget/categorical.html
+++ b/packages/components/src/components/as-histogram-widget/categorical.html
@@ -27,7 +27,7 @@
 </head>
 
 <body>
-  <as-histogram-widget x-label="x-axis" y-label="y-axis" responsive show-clear heading="Business Volume" description="Description">
+  <as-histogram-widget x-label="x-axis" y-label="y-axis" responsive show-clear-button heading="Business Volume" description="Description">
   </as-histogram-widget>
 
   <script>

--- a/packages/components/src/components/as-histogram-widget/responsive.html
+++ b/packages/components/src/components/as-histogram-widget/responsive.html
@@ -27,7 +27,7 @@
 </head>
 
 <body>
-  <as-histogram-widget x-label="x-axis" y-label="y-axis" responsive show-clear heading="Business Volume" description="Description">
+  <as-histogram-widget x-label="x-axis" y-label="y-axis" responsive show-clear-button heading="Business Volume" description="Description">
   </as-histogram-widget>
 
   <script>

--- a/packages/components/src/components/as-time-series-widget/README.md
+++ b/packages/components/src/components/as-time-series-widget/README.md
@@ -1,9 +1,11 @@
 The time series widget displays a histogram widget with the ability of display dates on the x-axis, as well as controlling and displaying animations.
 
 ```html
-noSource: true
----
-<iframe src="/examples/components/as-time-series-widget/simple.html" style="width: 100%; height: 300px;">
+noSource: true ---
+<iframe
+  src="/examples/components/as-time-series-widget/simple.html"
+  style="width: 100%; height: 300px;"
+></iframe>
 ```
 
 [See example](/developers/airship/examples/#example-as-time-series-simple)
@@ -32,6 +34,10 @@ Whether the animation is playing or not. Play / Pause button icon depends on thi
 
 How much the animation has progressed. Must be a number between 0 and 100.
 
+#### **showClearButton**: boolean = false
+
+If truthy, it'll show a button to clear the histogram selection. Default value is `false`.
+
 #### **timeFormat**: string = '%x - %X'
 
 A string represeting a format [compatible with d3-time-format](https://github.com/d3/d3-time-format#locale_format). It will be used to format the X-Axis of the histogram. It is set to default '%x - %X'. If it is set to 'auto', it will use a default format depending on the input type (date or number)
@@ -39,7 +45,6 @@ A string represeting a format [compatible with d3-time-format](https://github.co
 #### **timeFormatLocale**: Object
 
 A Javascript object that localizes some of the format. Again, must be [compatible with d3-time-format](https://github.com/d3/d3-time-format#locales)
-
 
 ### Events
 

--- a/packages/components/src/components/as-time-series-widget/as-time-series-widget.e2e.ts
+++ b/packages/components/src/components/as-time-series-widget/as-time-series-widget.e2e.ts
@@ -24,6 +24,16 @@ describe('as-time-series-widget', () => {
       expect(actual).toBeFalsy();
     });
 
+    it('should not render button when animated is false with show-clear-button', async () => {
+      const element: E2EElement = await page.find('as-time-series-widget');
+      element.setProperty('show-clear-button', 'false');
+      await page.waitForChanges();
+
+      const actual = await page.find('.as-time-series--play-button');
+
+      expect(actual).toBeFalsy();
+    });
+
     it('should not render the scrubber container', async () => {
       await page.find('as-time-series-widget');
       await page.waitForChanges();

--- a/packages/components/src/components/as-time-series-widget/as-time-series-widget.tsx
+++ b/packages/components/src/components/as-time-series-widget/as-time-series-widget.tsx
@@ -58,12 +58,22 @@ export class TimeSeriesWidget {
   @Prop() public showHeader: boolean = true;
 
   /**
+   * Deprecated, use showClearButton instead.
+   * Display a clear button that clears the histogram selection.
+   *
+   * @type {boolean}
+   * @memberof HistogramWidget
+   * @deprecated
+   */
+  @Prop() public showClear: boolean;
+
+  /**
    * Display a clear button that clears the histogram selection.
    *
    * @type {boolean}
    * @memberof HistogramWidget
    */
-  @Prop() public showClear: boolean;
+  @Prop() public showClearButton: boolean;
 
   /**
    * Disables selection brushes and events for the widget
@@ -421,7 +431,7 @@ export class TimeSeriesWidget {
         heading={this.heading}
         description={this.description}
         showHeader={this.showHeader}
-        showClear={this.showClear}
+        showClearButton={this.showClearButton}
         disableInteractivity={this.disableInteractivity}
         data={this.data}
         backgroundData={this._backgroundData}

--- a/packages/components/src/components/as-time-series-widget/basic.html
+++ b/packages/components/src/components/as-time-series-widget/basic.html
@@ -31,7 +31,7 @@
     animated
     x-label='asdf'
     responsive
-    show-clear
+    show-clear-button
     heading="A time series"
     description="hooola"
   >

--- a/packages/components/src/components/as-time-series-widget/cordoba.html
+++ b/packages/components/src/components/as-time-series-widget/cordoba.html
@@ -34,7 +34,7 @@
                       heading='Animation'
                       description='controls'
                       time-format='%Q'
-                      show-clear
+                      show-clear-button
                     >
                     </as-time-series-widget>
                   </div>

--- a/packages/smoke/cdn/smoke_0.html
+++ b/packages/smoke/cdn/smoke_0.html
@@ -137,7 +137,7 @@
       </div>
       <footer class="as-map-footer">
         <div class="as-box">
-          <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear-button></as-histogram-widget>
         </div>
         <div class="as-box">
           <as-stacked-bar-widget id="stackedFooter" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
@@ -196,7 +196,7 @@
       </div>
       <div class="as-container as-container--scrollable">
         <div class="as-box as-box--border">
-          <as-histogram-widget id="histogramSidebar" heading="Title" description="Description" show-header show-clear hidden></as-histogram-widget>
+          <as-histogram-widget id="histogramSidebar" heading="Title" description="Description" show-header show-clear-button hidden></as-histogram-widget>
         </div>
         <div class="as-box">
           <h1 class="as-title">Some content</h1>

--- a/packages/smoke/cdn/smoke_1.html
+++ b/packages/smoke/cdn/smoke_1.html
@@ -40,7 +40,7 @@
                   </div>
                   <div class="as-box">
                     <as-histogram-widget
-                      show-clear
+                      show-clear-button
                       id="year"
                       heading="Year"
                       description='in which building was registered'

--- a/packages/smoke/current/ffox_layout.html
+++ b/packages/smoke/current/ffox_layout.html
@@ -51,7 +51,7 @@
           <as-stacked-bar-widget id="stackedFooter" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
         </div>
         <div class="as-box">
-          <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear-button></as-histogram-widget>
         </div>
       </footer>
     </main>

--- a/packages/smoke/current/smoke_0.html
+++ b/packages/smoke/current/smoke_0.html
@@ -137,7 +137,7 @@
       </div>
       <footer class="as-map-footer">
         <div class="as-box">
-          <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear-button></as-histogram-widget>
         </div>
         <div class="as-box">
           <as-stacked-bar-widget id="stackedFooter" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
@@ -231,7 +231,7 @@
       </div>
       <div class="as-container as-container--scrollable">
         <div class="as-box as-box--border">
-          <as-histogram-widget id="histogramSidebar" heading="Title" description="Description" show-header show-clear hidden></as-histogram-widget>
+          <as-histogram-widget id="histogramSidebar" heading="Title" description="Description" show-header show-clear-button hidden></as-histogram-widget>
         </div>
         <div class="as-box">
           <h1 class="as-title">Some content</h1>

--- a/packages/smoke/npm/smoke_0.html
+++ b/packages/smoke/npm/smoke_0.html
@@ -137,14 +137,14 @@
       </div>
       <footer class="as-map-footer">
         <div class="as-box">
-          <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear></as-histogram-widget>
+          <as-histogram-widget id="histogramFooter" heading="Title" description="Description" show-header show-clear-button></as-histogram-widget>
         </div>
         <div class="as-box">
           <as-stacked-bar-widget id="stackedFooter" show-legend="true" heading="Star Wars Revenue" description="Description"></as-stacked-bar-widget>
         </div>
         <div class="as-box">
           <as-category-widget
-            show-clear
+            show-clear-button
             id="typeCat"
             heading="Type"
           >
@@ -198,7 +198,7 @@
       </div>
       <div class="as-container as-container--scrollable">
         <div class="as-box as-box--border">
-          <as-histogram-widget id="histogramSidebar" heading="Title" description="Description" show-header show-clear hidden></as-histogram-widget>
+          <as-histogram-widget id="histogramSidebar" heading="Title" description="Description" show-header show-clear-button hidden></as-histogram-widget>
         </div>
         <div class="as-box">
           <h1 class="as-title">Some content</h1>


### PR DESCRIPTION
Add the parameter `show-clear-button` and mark as deprecated the `show-clear` option for histogram and time series widget.
This make those widgets having the same api as the rest of widgets.